### PR TITLE
This fixes NVRHI_BUILD_SHARED and linking RTXMU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ project(nvrhi VERSION 1.0.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(CMakeDependentOption)
 


### PR DESCRIPTION
This fixes:
```/usr/bin/ld: rtxmu/librtxmu.a(VkAccelStructManager.cpp.o): relocation R_X86_64_PC32 against symbol `_ZN5rtxmu7VkBlock10m_instanceE' can not be used when making a shared object; recompile with -fPIC```

I assume I need to sign the CLA somehow?

Cheers