### PR TITLE
Fix invalid argument for DX12 CreateHeap

### DIFF
--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -1094,6 +1094,7 @@ namespace nvrhi::d3d12
         bool m_MeshletsSupported = false;
         bool m_VariableRateShadingSupported = false;
 
+        D3D12_FEATURE_DATA_D3D12_OPTIONS  m_Options = {};
         D3D12_FEATURE_DATA_D3D12_OPTIONS5 m_Options5 = {};
         D3D12_FEATURE_DATA_D3D12_OPTIONS6 m_Options6 = {};
         D3D12_FEATURE_DATA_D3D12_OPTIONS7 m_Options7 = {};

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -521,7 +521,7 @@ namespace nvrhi::d3d12
             heapDesc.Flags = D3D12_HEAP_FLAG_ALLOW_ALL_BUFFERS_AND_TEXTURES;
             break;
         default:
-            utils::InvalidEnum( );
+            utils::InvalidEnum();
             return nullptr;
         }
 

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -512,18 +512,10 @@ namespace nvrhi::d3d12
         heapDesc.Properties.CreationNodeMask = 1; // no mGPU support in nvrhi so far
         heapDesc.Properties.VisibleNodeMask = 1;
 
-        switch (m_Options.ResourceHeapTier)
-        {
-        case D3D12_RESOURCE_HEAP_TIER_1:
+        if (m_Options.ResourceHeapTier == D3D12_RESOURCE_HEAP_TIER_1)
             heapDesc.Flags = D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES;
-            break;
-        case D3D12_RESOURCE_HEAP_TIER_2:
+        else
             heapDesc.Flags = D3D12_HEAP_FLAG_ALLOW_ALL_BUFFERS_AND_TEXTURES;
-            break;
-        default:
-            utils::InvalidEnum();
-            return nullptr;
-        }
 
         switch (d.type)
         {


### PR DESCRIPTION
This adds a heap tier check because the `D3D12_HEAP_FLAG_ALLOW_ALL_BUFFERS_AND_TEXTURES` flag is not supported for heap tier 1. I tested this on Windows 10 SDK 10.0.19041.0 and 10.0.20348.0.