### PR TITLE
Adding shared flags for D3D11 and 12 resources.

### DIFF
--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -390,6 +390,9 @@ namespace nvrhi
         bool isTypeless = false;
         bool isShadingRateSurface = false;
 
+        bool isSharedAcrossDevice = false;
+        bool isSharedAcrossAdapter = false;
+
         // Indicates that the texture is created with no backing memory,
         // and memory is bound to the texture later using bindTextureMemory.
         // On DX12, the texture resource is created at the time of memory binding.
@@ -581,6 +584,9 @@ namespace nvrhi
         bool keepInitialState = false;
 
         CpuAccessMode cpuAccess = CpuAccessMode::None;
+
+        bool isSharedAcrossDevice = false;
+        bool isSharedAcrossAdapter = false;
 
         constexpr BufferDesc& setByteSize(uint64_t value) { byteSize = value; return *this; }
         constexpr BufferDesc& setStructStride(uint32_t value) { structStride = value; return *this; }

--- a/src/d3d11/d3d11-buffer.cpp
+++ b/src/d3d11/d3d11-buffer.cpp
@@ -103,6 +103,11 @@ namespace nvrhi::d3d11
 
         desc11.StructureByteStride = (UINT)d.structStride;
 
+        if (d.isSharedAcrossDevice)
+            desc11.MiscFlags |= D3D11_RESOURCE_MISC_SHARED;
+        if (d.isSharedAcrossAdapter)
+            desc11.MiscFlags |= D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX | D3D11_RESOURCE_MISC_SHARED_NTHANDLE;
+
         RefCountPtr<ID3D11Buffer> newBuffer;
         const HRESULT res = m_Context.device->CreateBuffer(&desc11, nullptr, &newBuffer);
         if (FAILED(res))

--- a/src/d3d11/d3d11-texture.cpp
+++ b/src/d3d11/d3d11-texture.cpp
@@ -90,6 +90,12 @@ namespace nvrhi::d3d11
         if (cpuAccess == CpuAccessMode::Write)
             cpuAccessFlags = D3D11_CPU_ACCESS_WRITE;
 
+        UINT miscFlags = 0;
+        if (d.isSharedAcrossDevice)
+            miscFlags |= D3D11_RESOURCE_MISC_SHARED;
+        if (d.isSharedAcrossAdapter)
+            miscFlags |= D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX | D3D11_RESOURCE_MISC_SHARED_NTHANDLE;
+
         RefCountPtr<ID3D11Resource> pResource;
 
         switch (d.dimension)
@@ -105,7 +111,7 @@ namespace nvrhi::d3d11
             desc11.Usage = usage;
             desc11.BindFlags = bindFlags;
             desc11.CPUAccessFlags = cpuAccessFlags;
-            desc11.MiscFlags = 0;
+            desc11.MiscFlags = miscFlags;
 
             RefCountPtr<ID3D11Texture1D> newTexture;
             const HRESULT res = m_Context.device->CreateTexture1D(&desc11, nullptr, &newTexture);
@@ -141,9 +147,9 @@ namespace nvrhi::d3d11
             desc11.CPUAccessFlags = cpuAccessFlags;
 
             if (d.dimension == TextureDimension::TextureCube || d.dimension == TextureDimension::TextureCubeArray)
-                desc11.MiscFlags = D3D11_RESOURCE_MISC_TEXTURECUBE;
+                desc11.MiscFlags = miscFlags | D3D11_RESOURCE_MISC_TEXTURECUBE;
             else
-                desc11.MiscFlags = 0;
+                desc11.MiscFlags = miscFlags;
 
             RefCountPtr<ID3D11Texture2D> newTexture;
             const HRESULT res = m_Context.device->CreateTexture2D(&desc11, nullptr, &newTexture);
@@ -171,7 +177,7 @@ namespace nvrhi::d3d11
             desc11.Usage = usage;
             desc11.BindFlags = bindFlags;
             desc11.CPUAccessFlags = cpuAccessFlags;
-            desc11.MiscFlags = 0;
+            desc11.MiscFlags = miscFlags;
 
             RefCountPtr<ID3D11Texture3D> newTexture;
             HRESULT res = m_Context.device->CreateTexture3D(&desc11, nullptr, &newTexture);

--- a/src/d3d12/d3d12-buffer.cpp
+++ b/src/d3d12/d3d12-buffer.cpp
@@ -86,7 +86,15 @@ namespace nvrhi::d3d12
         }
 
         D3D12_HEAP_PROPERTIES heapProps = {};
+        D3D12_HEAP_FLAGS heapFlags = D3D12_HEAP_FLAG_NONE;
         D3D12_RESOURCE_STATES initialState = D3D12_RESOURCE_STATE_COMMON;
+
+        if (d.isSharedAcrossDevice)
+            heapFlags |= D3D12_HEAP_FLAG_SHARED;
+        if (d.isSharedAcrossAdapter) {
+            resourceDesc.Flags |= D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER;
+            heapFlags |= D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER;
+        }
 
         switch(buffer->desc.cpuAccess)
         {
@@ -108,7 +116,7 @@ namespace nvrhi::d3d12
 
         HRESULT res = m_Context.device->CreateCommittedResource(
             &heapProps,
-            D3D12_HEAP_FLAG_NONE,
+            heapFlags,
             &resourceDesc,
             initialState,
             nullptr,

--- a/src/vulkan/vulkan-buffer.cpp
+++ b/src/vulkan/vulkan-buffer.cpp
@@ -41,6 +41,12 @@ namespace nvrhi::vulkan
         if (desc.byteSize == 0)
             return nullptr;
 
+        if (desc.isSharedAcrossAdapter || desc.isSharedAcrossDevice) {
+            std::stringstream ss;
+            ss << "Vk layer doesn't support shared flags, since Vulkan's VkExternalMemoryHandleTypeFlagBits requires explicit definition of the other hand of the API. " << utils::DebugNameToString(desc.debugName);
+            m_Context.error(ss.str());
+            return nullptr;
+        }
 
         Buffer *buffer = new Buffer(m_Context, m_Allocator);
         buffer->desc = desc;

--- a/src/vulkan/vulkan-texture.cpp
+++ b/src/vulkan/vulkan-texture.cpp
@@ -307,6 +307,13 @@ namespace nvrhi::vulkan
 
     TextureHandle Device::createTexture(const TextureDesc& desc)
     {
+        if (desc.isSharedAcrossAdapter || desc.isSharedAcrossDevice) {
+            std::stringstream ss;
+            ss << "Vk layer doesn't support shared flags, since Vulkan's VkExternalMemoryHandleTypeFlagBits requires explicit definition of the other hand of the API. " << utils::DebugNameToString(desc.debugName);
+            m_Context.error(ss.str());
+            return TextureHandle();
+        }
+
         Texture *texture = new Texture(m_Context, m_Allocator);
         assert(texture);
         fillTextureInfo(texture, desc);


### PR DESCRIPTION
This change adds 'isSharedAcrossDevice' and 'isSharedAcrossAdapter' to TextureDesc and BufferDesc.
In D3D11 and 12, applying these flags will result in applying shared resource flags.
In VK, applying this flag will produce an error because it's too different the way to share resource against D3Ds.
VK needs information about the other hand's API to apply sharing flags.
