### PR TITLE
Added MemoryAllocateFlagsInfo for device address enabled buffers in VK

### DIFF
--- a/src/vulkan/vulkan-backend.h
+++ b/src/vulkan/vulkan-backend.h
@@ -266,7 +266,7 @@ namespace nvrhi::vulkan
             : m_Context(context)
         { }
 
-        vk::Result allocateBufferMemory(Buffer* buffer) const;
+        vk::Result allocateBufferMemory(Buffer* buffer, bool enableBufferAddress = false) const;
         void freeBufferMemory(Buffer* buffer) const;
 
         vk::Result allocateTextureMemory(Texture* texture) const;
@@ -274,7 +274,8 @@ namespace nvrhi::vulkan
 
         vk::Result allocateMemory(MemoryResource* res,
             vk::MemoryRequirements memRequirements,
-            vk::MemoryPropertyFlags memPropertyFlags) const;
+            vk::MemoryPropertyFlags memPropertyFlags,
+            bool enableDeviceAddress = false) const;
         void freeMemory(MemoryResource* res) const;
 
     private:

--- a/src/vulkan/vulkan-buffer.cpp
+++ b/src/vulkan/vulkan-buffer.cpp
@@ -121,7 +121,7 @@ namespace nvrhi::vulkan
 
         if (!desc.isVirtual)
         {
-            res = m_Allocator.allocateBufferMemory(buffer);
+            res = m_Allocator.allocateBufferMemory(buffer, (usageFlags & vk::BufferUsageFlagBits::eShaderDeviceAddress) != vk::BufferUsageFlags(0));
             CHECK_VK_FAIL(res)
 
             m_Context.nameVKObject(buffer->memory, vk::DebugReportObjectTypeEXT::eDeviceMemory, desc.debugName.c_str());


### PR DESCRIPTION
When enabling device address in VK,  vk::MemoryAllocateFlagsInfo is required in pNext chain when allocating VRAM.
Without this, VK validation layer produce an error message. 
