### PR TITLE
Use DirectX-Headers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,6 @@
 [submodule "thirdparty/Vulkan-Headers"]
 	path = thirdparty/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers.git
-
+[submodule "thirdparty/DirectX-Headers"]
+	path = thirdparty/DirectX-Headers
+	url = https://github.com/microsoft/DirectX-Headers.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,13 +239,7 @@ if (NVRHI_WITH_DX11)
         target_include_directories(${nvrhi_d3d11_target} PRIVATE include)
     endif()
 
-    target_link_libraries(${nvrhi_d3d11_target} 
-        PUBLIC
-            d3d11 
-            dxguid
-        PRIVATE
-            $<BUILD_INTERFACE:Microsoft::DirectX-Headers>
-    )
+    target_link_libraries(${nvrhi_d3d11_target} Microsoft::DirectX-Headers d3d11 dxguid)
 
     if (NVRHI_WITH_NVAPI)
         target_link_libraries(${nvrhi_d3d11_target} nvapi)
@@ -278,13 +272,7 @@ if (NVRHI_WITH_DX12)
         target_link_libraries(${nvrhi_d3d12_target} rtxmu)
     endif()
 
-    target_link_libraries(${nvrhi_d3d12_target} 
-        PUBLIC
-            d3d12 
-            dxguid
-        PRIVATE
-            $<BUILD_INTERFACE:Microsoft::DirectX-Headers>
-    )
+    target_link_libraries(${nvrhi_d3d12_target} Microsoft::DirectX-Headers d3d12 dxguid)
 
     if (NVRHI_WITH_NVAPI)
         target_link_libraries(${nvrhi_d3d12_target} nvapi)
@@ -317,7 +305,7 @@ if (NVRHI_WITH_VULKAN)
         target_link_libraries(${nvrhi_vulkan_target} rtxmu)
     endif()
 
-    target_link_libraries(${nvrhi_vulkan_target} PRIVATE $<BUILD_INTERFACE:Vulkan-Headers>)
+    target_link_libraries(${nvrhi_vulkan_target} Vulkan-Headers)
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ if (NVRHI_WITH_VULKAN)
     add_subdirectory(thirdparty/Vulkan-Headers)
 endif()
 
+if (NVRHI_WITH_DX11 OR NVRHI_WITH_DX12)
+    add_subdirectory(thirdparty/DirectX-Headers)
+endif()
+
 if (NVRHI_WITH_RTXMU)
     if (TARGET Vulkan-Headers)
         get_target_property(RTXMU_VULKAN_INCLUDE_DIR Vulkan-Headers INTERFACE_INCLUDE_DIRECTORIES)
@@ -235,7 +239,13 @@ if (NVRHI_WITH_DX11)
         target_include_directories(${nvrhi_d3d11_target} PRIVATE include)
     endif()
 
-    target_link_libraries(${nvrhi_d3d11_target} d3d11 dxguid)
+    target_link_libraries(${nvrhi_d3d11_target} 
+        PUBLIC
+            d3d11 
+            dxguid
+        PRIVATE
+            $<BUILD_INTERFACE:Microsoft::DirectX-Headers>
+    )
 
     if (NVRHI_WITH_NVAPI)
         target_link_libraries(${nvrhi_d3d11_target} nvapi)
@@ -268,7 +278,13 @@ if (NVRHI_WITH_DX12)
         target_link_libraries(${nvrhi_d3d12_target} rtxmu)
     endif()
 
-    target_link_libraries(${nvrhi_d3d12_target} d3d12 dxguid)
+    target_link_libraries(${nvrhi_d3d12_target} 
+        PUBLIC
+            d3d12 
+            dxguid
+        PRIVATE
+            $<BUILD_INTERFACE:Microsoft::DirectX-Headers>
+    )
 
     if (NVRHI_WITH_NVAPI)
         target_link_libraries(${nvrhi_d3d12_target} nvapi)
@@ -301,7 +317,7 @@ if (NVRHI_WITH_VULKAN)
         target_link_libraries(${nvrhi_vulkan_target} rtxmu)
     endif()
 
-    target_link_libraries(${nvrhi_vulkan_target} Vulkan-Headers)
+    target_link_libraries(${nvrhi_vulkan_target} PRIVATE $<BUILD_INTERFACE:Vulkan-Headers>)
 
 endif()
 

--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -1376,7 +1376,7 @@ namespace nvrhi
             InstanceDesc& setBLAS(IAccelStruct* value) { bottomLevelAS = value; return *this; }
         };
 
-        static_assert(sizeof(InstanceDesc) == 64);
+        static_assert(sizeof(InstanceDesc) == 64, "InstanceDesc should be 64 bytes");
 
         enum class AccelStructBuildFlags : uint8_t
         {

--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -1376,7 +1376,7 @@ namespace nvrhi
             InstanceDesc& setBLAS(IAccelStruct* value) { bottomLevelAS = value; return *this; }
         };
 
-        static_assert(sizeof(InstanceDesc) == 64, "InstanceDesc should be 64 bytes");
+        static_assert(sizeof(InstanceDesc) == 64, "sizeof(InstanceDesc) is supposed to be 64 bytes");
 
         enum class AccelStructBuildFlags : uint8_t
         {

--- a/src/common/dxgi-format.h
+++ b/src/common/dxgi-format.h
@@ -23,7 +23,7 @@
 #pragma once
 
 #include <nvrhi/nvrhi.h>
-#include <dxgi.h>
+#include <directx/dxgiformat.h>
 
 namespace nvrhi
 {

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -22,6 +22,11 @@
 
 #pragma once
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include <directx/d3d12.h>
 #include <nvrhi/d3d12.h>
 
 #ifndef NVRHI_D3D12_WITH_NVAPI


### PR DESCRIPTION
Using DirectX-Headers would allow to be not dependent on the installed windows SDK for newer DX-SDK features. The DirectX-Headers are only used in private source files which should not affect when this library is consumed.
The DirectX-Headers submodule is pinned to the latest stable release v1.602.0.
I also changed one static_assert which was missing the error message.