### PR TITLE
Fixed wrong miss shader group handles region size

### DIFF
--- a/src/vulkan/vulkan-raytracing.cpp
+++ b/src/vulkan/vulkan-raytracing.cpp
@@ -716,7 +716,7 @@ namespace nvrhi::vulkan
                         shaderGroupHandleSize);
                     sbtIndex++;
                 }
-                missHandles.setSize(shaderGroupBaseAlignment * uint32_t(shaderTable->hitGroups.size()));
+                missHandles.setSize(shaderGroupBaseAlignment * uint32_t(shaderTable->missShaders.size()));
                 missHandles.setStride(shaderGroupBaseAlignment);
             }
 


### PR DESCRIPTION
During shader binding table construction wrong array (with hit groups) was used to determine range size for miss shader group handles. 