### PR TITLE
Extend existing drawIndirect by drawCount

### DIFF
--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -2395,7 +2395,7 @@ namespace nvrhi
         virtual void setGraphicsState(const GraphicsState& state) = 0;
         virtual void draw(const DrawArguments& args) = 0;
         virtual void drawIndexed(const DrawArguments& args) = 0;
-        virtual void drawIndirect(uint32_t drawCount, uint32_t offsetBytes) = 0;
+        virtual void drawIndirect(uint32_t offsetBytes, uint32_t drawCount = 1) = 0;
         
         virtual void setComputeState(const ComputeState& state) = 0;
         virtual void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) = 0;

--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -2128,6 +2128,19 @@ namespace nvrhi
         constexpr DrawArguments& setStartInstanceLocation(uint32_t value) { startInstanceLocation = value; return *this; }
     };
 
+    struct DrawIndirectArguments
+    {
+        uint32_t vertexCount = 0;
+        uint32_t instanceCount = 1;
+        uint32_t startVertexLocation = 0;
+        uint32_t startInstanceLocation = 0;
+
+        constexpr DrawIndirectArguments& setVertexCount(uint32_t value) { vertexCount = value; return *this; }
+        constexpr DrawIndirectArguments& setInstanceCount(uint32_t value) { instanceCount = value; return *this; }
+        constexpr DrawIndirectArguments& setStartVertexLocation(uint32_t value) { startVertexLocation = value; return *this; }
+        constexpr DrawIndirectArguments& setStartInstanceLocation(uint32_t value) { startInstanceLocation = value; return *this; }
+    };
+
     struct ComputeState
     {
         IComputePipeline* pipeline = nullptr;
@@ -2382,7 +2395,7 @@ namespace nvrhi
         virtual void setGraphicsState(const GraphicsState& state) = 0;
         virtual void draw(const DrawArguments& args) = 0;
         virtual void drawIndexed(const DrawArguments& args) = 0;
-        virtual void drawIndirect(uint32_t offsetBytes) = 0;
+        virtual void drawIndirect(uint32_t drawCount, uint32_t offsetBytes) = 0;
         
         virtual void setComputeState(const ComputeState& state) = 0;
         virtual void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) = 0;

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -303,7 +303,7 @@ namespace nvrhi::d3d11
         void setGraphicsState(const GraphicsState& state) override;
         void draw(const DrawArguments& args) override;
         void drawIndexed(const DrawArguments& args) override;
-        void drawIndirect(uint32_t offsetBytes) override;
+        void drawIndirect(uint32_t drawCount, uint32_t offsetBytes) override;
 
         void setComputeState(const ComputeState& state) override;
         void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) override;

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -303,7 +303,7 @@ namespace nvrhi::d3d11
         void setGraphicsState(const GraphicsState& state) override;
         void draw(const DrawArguments& args) override;
         void drawIndexed(const DrawArguments& args) override;
-        void drawIndirect(uint32_t drawCount, uint32_t offsetBytes) override;
+        void drawIndirect(uint32_t offsetBytes, uint32_t drawCount) override;
 
         void setComputeState(const ComputeState& state) override;
         void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) override;

--- a/src/d3d11/d3d11-graphics.cpp
+++ b/src/d3d11/d3d11-graphics.cpp
@@ -357,7 +357,7 @@ namespace nvrhi::d3d11
         m_Context.immediateContext->DrawIndexedInstanced(args.vertexCount, args.instanceCount, args.startIndexLocation, args.startVertexLocation, args.startInstanceLocation);
     }
 
-    void CommandList::drawIndirect(uint32_t offsetBytes)
+    void CommandList::drawIndirect(uint32_t /*drawCount*/, uint32_t offsetBytes)
     {
         Buffer* indirectParams = checked_cast<Buffer*>(m_CurrentIndirectBuffer.Get());
         

--- a/src/d3d11/d3d11-graphics.cpp
+++ b/src/d3d11/d3d11-graphics.cpp
@@ -357,7 +357,7 @@ namespace nvrhi::d3d11
         m_Context.immediateContext->DrawIndexedInstanced(args.vertexCount, args.instanceCount, args.startIndexLocation, args.startVertexLocation, args.startInstanceLocation);
     }
 
-    void CommandList::drawIndirect(uint32_t /*drawCount*/, uint32_t offsetBytes)
+    void CommandList::drawIndirect(uint32_t offsetBytes, uint32_t /*drawCount*/)
     {
         Buffer* indirectParams = checked_cast<Buffer*>(m_CurrentIndirectBuffer.Get());
         

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -853,7 +853,7 @@ namespace nvrhi::d3d12
         void setGraphicsState(const GraphicsState& state) override;
         void draw(const DrawArguments& args) override;
         void drawIndexed(const DrawArguments& args) override;
-        void drawIndirect(uint32_t offsetBytes) override;
+        void drawIndirect(uint32_t drawCount, uint32_t offsetBytes) override;
 
         void setComputeState(const ComputeState& state) override;
         void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) override;

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -853,7 +853,7 @@ namespace nvrhi::d3d12
         void setGraphicsState(const GraphicsState& state) override;
         void draw(const DrawArguments& args) override;
         void drawIndexed(const DrawArguments& args) override;
-        void drawIndirect(uint32_t drawCount, uint32_t offsetBytes) override;
+        void drawIndirect(uint32_t offsetBytes, uint32_t drawCount) override;
 
         void setComputeState(const ComputeState& state) override;
         void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) override;

--- a/src/d3d12/d3d12-graphics.cpp
+++ b/src/d3d12/d3d12-graphics.cpp
@@ -538,14 +538,14 @@ namespace nvrhi::d3d12
         m_ActiveCommandList->commandList->DrawIndexedInstanced(args.vertexCount, args.instanceCount, args.startIndexLocation, args.startVertexLocation, args.startInstanceLocation);
     }
 
-    void CommandList::drawIndirect(uint32_t offsetBytes)
+    void CommandList::drawIndirect(uint32_t drawCount, uint32_t offsetBytes)
     {
         Buffer* indirectParams = checked_cast<Buffer*>(m_CurrentGraphicsState.indirectParams);
         assert(indirectParams); // validation layer handles this
 
         updateGraphicsVolatileBuffers();
 
-        m_ActiveCommandList->commandList->ExecuteIndirect(m_Context.drawIndirectSignature, 1, indirectParams->resource, offsetBytes, nullptr, 0);
+        m_ActiveCommandList->commandList->ExecuteIndirect(m_Context.drawIndirectSignature, drawCount, indirectParams->resource, offsetBytes, nullptr, 0);
     }
     
     DX12_ViewportState convertViewportState(const RasterState& rasterState, const FramebufferInfo& framebufferInfo, const ViewportState& vpState)

--- a/src/d3d12/d3d12-graphics.cpp
+++ b/src/d3d12/d3d12-graphics.cpp
@@ -538,7 +538,7 @@ namespace nvrhi::d3d12
         m_ActiveCommandList->commandList->DrawIndexedInstanced(args.vertexCount, args.instanceCount, args.startIndexLocation, args.startVertexLocation, args.startInstanceLocation);
     }
 
-    void CommandList::drawIndirect(uint32_t drawCount, uint32_t offsetBytes)
+    void CommandList::drawIndirect(uint32_t offsetBytes, uint32_t drawCount)
     {
         Buffer* indirectParams = checked_cast<Buffer*>(m_CurrentGraphicsState.indirectParams);
         assert(indirectParams); // validation layer handles this

--- a/src/validation/validation-backend.h
+++ b/src/validation/validation-backend.h
@@ -169,7 +169,7 @@ namespace nvrhi::validation
         void setGraphicsState(const GraphicsState& state) override;
         void draw(const DrawArguments& args) override;
         void drawIndexed(const DrawArguments& args) override;
-        void drawIndirect(uint32_t offsetBytes) override;
+        void drawIndirect(uint32_t drawCount, uint32_t offsetBytes) override;
 
         void setComputeState(const ComputeState& state) override;
         void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) override;

--- a/src/validation/validation-backend.h
+++ b/src/validation/validation-backend.h
@@ -169,7 +169,7 @@ namespace nvrhi::validation
         void setGraphicsState(const GraphicsState& state) override;
         void draw(const DrawArguments& args) override;
         void drawIndexed(const DrawArguments& args) override;
-        void drawIndirect(uint32_t drawCount, uint32_t offsetBytes) override;
+        void drawIndirect(uint32_t offsetBytes, uint32_t drawCount) override;
 
         void setComputeState(const ComputeState& state) override;
         void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) override;

--- a/src/validation/validation-commandlist.cpp
+++ b/src/validation/validation-commandlist.cpp
@@ -683,8 +683,14 @@ namespace nvrhi::validation
         m_CommandList->drawIndexed(args);
     }
 
-    void CommandListWrapper::drawIndirect(uint32_t offsetBytes)
+    void CommandListWrapper::drawIndirect(uint32_t drawCount, uint32_t offsetBytes)
     {
+        if (drawCount == 0)
+        {
+            error("drawCount is is 0");
+            return;
+        }
+
         if (!requireOpenState())
             return;
 
@@ -701,7 +707,7 @@ namespace nvrhi::validation
         if (!validatePushConstants("graphics", "setGraphicsState"))
             return;
 
-        m_CommandList->drawIndirect(offsetBytes);
+        m_CommandList->drawIndirect(drawCount, offsetBytes);
     }
 
     void CommandListWrapper::setComputeState(const ComputeState& state)

--- a/src/validation/validation-commandlist.cpp
+++ b/src/validation/validation-commandlist.cpp
@@ -683,7 +683,7 @@ namespace nvrhi::validation
         m_CommandList->drawIndexed(args);
     }
 
-    void CommandListWrapper::drawIndirect(uint32_t drawCount, uint32_t offsetBytes)
+    void CommandListWrapper::drawIndirect(uint32_t offsetBytes, uint32_t drawCount)
     {
         if (drawCount == 0)
         {
@@ -707,7 +707,7 @@ namespace nvrhi::validation
         if (!validatePushConstants("graphics", "setGraphicsState"))
             return;
 
-        m_CommandList->drawIndirect(drawCount, offsetBytes);
+        m_CommandList->drawIndirect(offsetBytes, drawCount);
     }
 
     void CommandListWrapper::setComputeState(const ComputeState& state)

--- a/src/validation/validation-commandlist.cpp
+++ b/src/validation/validation-commandlist.cpp
@@ -687,7 +687,7 @@ namespace nvrhi::validation
     {
         if (drawCount == 0)
         {
-            error("drawCount is is 0");
+            error("drawCount is 0");
             return;
         }
 

--- a/src/vulkan/vulkan-backend.h
+++ b/src/vulkan/vulkan-backend.h
@@ -1124,7 +1124,7 @@ namespace nvrhi::vulkan
         void setGraphicsState(const GraphicsState& state) override;
         void draw(const DrawArguments& args) override;
         void drawIndexed(const DrawArguments& args) override;
-        void drawIndirect(uint32_t drawCount, uint32_t offsetBytes) override;
+        void drawIndirect(uint32_t offsetBytes, uint32_t drawCount) override;
 
         void setComputeState(const ComputeState& state) override;
         void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) override;

--- a/src/vulkan/vulkan-backend.h
+++ b/src/vulkan/vulkan-backend.h
@@ -1124,7 +1124,7 @@ namespace nvrhi::vulkan
         void setGraphicsState(const GraphicsState& state) override;
         void draw(const DrawArguments& args) override;
         void drawIndexed(const DrawArguments& args) override;
-        void drawIndirect(uint32_t offsetBytes) override;
+        void drawIndirect(uint32_t drawCount, uint32_t offsetBytes) override;
 
         void setComputeState(const ComputeState& state) override;
         void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) override;

--- a/src/vulkan/vulkan-graphics.cpp
+++ b/src/vulkan/vulkan-graphics.cpp
@@ -807,7 +807,7 @@ namespace nvrhi::vulkan
             args.startInstanceLocation);
     }
 
-    void CommandList::drawIndirect(uint32_t offsetBytes)
+    void CommandList::drawIndirect(uint32_t drawCount, uint32_t offsetBytes)
     {
         assert(m_CurrentCmdBuf);
 
@@ -816,8 +816,7 @@ namespace nvrhi::vulkan
         Buffer* indirectParams = checked_cast<Buffer*>(m_CurrentGraphicsState.indirectParams);
         assert(indirectParams);
 
-        // TODO: is this right?
-        m_CurrentCmdBuf->cmdBuf.drawIndirect(indirectParams->buffer, offsetBytes, 1, 0);
+        m_CurrentCmdBuf->cmdBuf.drawIndirect(indirectParams->buffer, offsetBytes, drawCount, sizeof(DrawIndirectArguments));
     }
 
 } // namespace nvrhi::vulkan

--- a/src/vulkan/vulkan-graphics.cpp
+++ b/src/vulkan/vulkan-graphics.cpp
@@ -807,7 +807,7 @@ namespace nvrhi::vulkan
             args.startInstanceLocation);
     }
 
-    void CommandList::drawIndirect(uint32_t drawCount, uint32_t offsetBytes)
+    void CommandList::drawIndirect(uint32_t offsetBytes, uint32_t drawCount)
     {
         assert(m_CurrentCmdBuf);
 


### PR DESCRIPTION
DrawIndirect seems to be not really usable right now as it does not allow to set a drawCount.
This PR adds drawCount to the drawIndirect method. This will be DX12 and Vulkan only.
For convenience I added the DrawIndirectArguments struct which matches the VkDrawIndirectCommand and D3D12_DRAW_ARGUMENTS.

This is a breaking API change as the drawIndirect signature changed but I think this is not used currently?