### PR TITLE
Fix potential hit group export name corruption on D3D12.

### DIFF
--- a/src/d3d12/d3d12-raytracing.cpp
+++ b/src/d3d12/d3d12-raytracing.cpp
@@ -414,6 +414,7 @@ namespace nvrhi::d3d12
         std::vector<D3D12_HIT_GROUP_DESC> d3dHitGroups;
         std::unordered_map<IShader*, std::wstring> hitGroupShaderNames;
         std::vector<std::wstring> hitGroupExportNames;
+        hitGroupExportNames.reserve(desc.hitGroups.size());
 
         for (const rt::PipelineHitGroupDesc& hitGroupDesc : desc.hitGroups)
         {


### PR DESCRIPTION
Small string optimization causes hit group export names in D3D12 structs to point at invalid memory whenever the internal capacity of `hitGroupExportNames` gets reallocated. Reserving the vector beforehand fixes this.