### PR TITLE
Fixed AccelStruct destructor to clean up RTXMU resources

### DIFF
--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -671,6 +671,8 @@ namespace nvrhi::d3d12
             : m_Context(context)
         { }
 
+        ~AccelStruct() override;
+
         void createSRV(size_t descriptor) const;
 
         Object getNativeObject(ObjectType objectType) override;

--- a/src/d3d12/d3d12-raytracing.cpp
+++ b/src/d3d12/d3d12-raytracing.cpp
@@ -187,6 +187,18 @@ namespace nvrhi::d3d12
         return align(requiredSize, uint32_t(D3D12_RAYTRACING_SHADER_TABLE_BYTE_ALIGNMENT));
     }
 
+    AccelStruct::~AccelStruct()
+    {
+#ifdef NVRHI_WITH_RTXMU
+        bool isManaged = desc.isTopLevel;
+        if (!isManaged)
+        {
+            std::vector<uint64_t> delAccel = { rtxmuId };
+            m_Context.rtxMemUtil->RemoveAccelerationStructures(delAccel);
+        }
+#endif // NVRHI_WITH_RTXMU
+    }
+
     Object AccelStruct::getNativeObject(ObjectType objectType)
     {
         if (dataBuffer)

--- a/src/vulkan/vulkan-raytracing.cpp
+++ b/src/vulkan/vulkan-raytracing.cpp
@@ -579,6 +579,12 @@ namespace nvrhi::vulkan
     {
 #ifdef NVRHI_WITH_RTXMU
         bool isManaged = desc.isTopLevel;
+        if (!isManaged)
+        {
+            std::vector<uint64_t> delAccel = { rtxmuId };
+            m_Context.rtxMemUtil->RemoveAccelerationStructures(delAccel);
+            rtxmuId = ~0ull;
+        }
 #else
         bool isManaged = true;
 #endif


### PR DESCRIPTION
As mentioned in issue #27, this will in the long run fix the validation errors, and clean up RTXMU resources.