### PR TITLE
Extend resource sharing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,12 @@ if (NVRHI_WITH_VULKAN)
         set_target_properties(${nvrhi_vulkan_target} PROPERTIES FOLDER "NVRHI")
         target_include_directories(${nvrhi_vulkan_target} PRIVATE include)
     endif()
+    
+    if(WIN32)
+        target_compile_definitions(${nvrhi_vulkan_target} PRIVATE 
+                VK_USE_PLATFORM_WIN32_KHR
+                NOMINMAX)
+    endif()
 
     if (NVRHI_WITH_RTXMU)
         target_compile_definitions(${nvrhi_vulkan_target} PUBLIC NVRHI_WITH_RTXMU=1)

--- a/include/nvrhi/common/resource.h
+++ b/include/nvrhi/common/resource.h
@@ -79,6 +79,8 @@ namespace nvrhi
         constexpr ObjectType VK_DescriptorSet                       = 0x00030011;
         constexpr ObjectType VK_PipelineLayout                      = 0x00030012;
         constexpr ObjectType VK_Pipeline                            = 0x00030013;
+
+        constexpr ObjectType SharedHandle                           = 0x00040001;
     };
 
     struct Object

--- a/include/nvrhi/common/resource.h
+++ b/include/nvrhi/common/resource.h
@@ -39,6 +39,8 @@ namespace nvrhi
 
     namespace ObjectTypes
     {
+        constexpr ObjectType SharedHandle                           = 0x00000001;
+
         constexpr ObjectType D3D11_Device                           = 0x00010001;
         constexpr ObjectType D3D11_DeviceContext                    = 0x00010002;
         constexpr ObjectType D3D11_Resource                         = 0x00010003;
@@ -79,8 +81,6 @@ namespace nvrhi
         constexpr ObjectType VK_DescriptorSet                       = 0x00030011;
         constexpr ObjectType VK_PipelineLayout                      = 0x00030012;
         constexpr ObjectType VK_Pipeline                            = 0x00030013;
-
-        constexpr ObjectType SharedHandle                           = 0x00040001;
     };
 
     struct Object

--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -523,7 +523,6 @@ namespace nvrhi
     {
     public:
         [[nodiscard]] virtual const TextureDesc& getDesc() const = 0;
-        [[nodiscard]] virtual void* getSharedHandle() const = 0;
 
         // Similar to getNativeObject, returns a native view for a specified set of subresources. Returns nullptr if unavailable.
         // TODO: on D3D12, the views might become invalid later if the view heap is grown/reallocated, we should do something about that.
@@ -656,7 +655,6 @@ namespace nvrhi
     {
     public:
         [[nodiscard]] virtual const BufferDesc& getDesc() const = 0;
-        [[nodiscard]] virtual void* getSharedHandle() const = 0;
     };
 
     typedef RefCountPtr<IBuffer> BufferHandle;

--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -380,7 +380,7 @@ namespace nvrhi
 
         // D3D11: adds D3D11_RESOURCE_MISC_SHARED
         // D3D12: adds D3D12_HEAP_FLAG_SHARED
-        // Vulkan: ignored
+        // Vulkan: adds vk::ExternalMemoryImageCreateInfo and vk::ExportMemoryAllocateInfo/vk::ExternalMemoryBufferCreateInfo
         Shared              = 0x01,
 
         // D3D11: adds (D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX | D3D11_RESOURCE_MISC_SHARED_NTHANDLE)
@@ -523,6 +523,7 @@ namespace nvrhi
     {
     public:
         [[nodiscard]] virtual const TextureDesc& getDesc() const = 0;
+        [[nodiscard]] virtual void* getSharedHandle() const = 0;
 
         // Similar to getNativeObject, returns a native view for a specified set of subresources. Returns nullptr if unavailable.
         // TODO: on D3D12, the views might become invalid later if the view heap is grown/reallocated, we should do something about that.
@@ -655,6 +656,7 @@ namespace nvrhi
     {
     public:
         [[nodiscard]] virtual const BufferDesc& getDesc() const = 0;
+        [[nodiscard]] virtual void* getSharedHandle() const = 0;
     };
 
     typedef RefCountPtr<IBuffer> BufferHandle;

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -72,7 +72,6 @@ namespace nvrhi::d3d11
 
         Texture(const Context& context) : m_Context(context) { }
         const TextureDesc& getDesc() const override { return desc; }
-        void* getSharedHandle() const;
         Object getNativeObject(ObjectType objectType) override;
         Object getNativeView(ObjectType objectType, Format format, TextureSubresourceSet subresources, TextureDimension dimension, bool isReadOnlyDSV = false) override;
 
@@ -108,7 +107,6 @@ namespace nvrhi::d3d11
         
         Buffer(const Context& context) : m_Context(context) { }
         const BufferDesc& getDesc() const override { return desc; }
-        void* getSharedHandle() const override;
         Object getNativeObject(ObjectType objectType) override;
 
         ID3D11ShaderResourceView* getSRV(Format format, BufferRange range, ResourceType type);

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -68,9 +68,11 @@ namespace nvrhi::d3d11
     public:
         TextureDesc desc;
         RefCountPtr<ID3D11Resource> resource;
+        HANDLE sharedHandle = nullptr;
 
         Texture(const Context& context) : m_Context(context) { }
         const TextureDesc& getDesc() const override { return desc; }
+        void* getSharedHandle() const;
         Object getNativeObject(ObjectType objectType) override;
         Object getNativeView(ObjectType objectType, Format format, TextureSubresourceSet subresources, TextureDimension dimension, bool isReadOnlyDSV = false) override;
 
@@ -102,9 +104,11 @@ namespace nvrhi::d3d11
     public:
         BufferDesc desc;
         RefCountPtr<ID3D11Buffer> resource;
+        HANDLE sharedHandle = nullptr;
         
         Buffer(const Context& context) : m_Context(context) { }
         const BufferDesc& getDesc() const override { return desc; }
+        void* getSharedHandle() const override;
         Object getNativeObject(ObjectType objectType) override;
 
         ID3D11ShaderResourceView* getSRV(Format format, BufferRange range, ResourceType type);

--- a/src/d3d11/d3d11-buffer.cpp
+++ b/src/d3d11/d3d11-buffer.cpp
@@ -38,6 +38,8 @@ namespace nvrhi::d3d11
         case ObjectTypes::D3D11_Resource:
         case ObjectTypes::D3D11_Buffer:
             return Object(resource.Get());
+        case ObjectTypes::SharedHandle:
+            return Object(sharedHandle);
         default:
             return nullptr;
         }
@@ -275,11 +277,6 @@ namespace nvrhi::d3d11
         buffer->desc = desc;
         buffer->resource = pBuffer;
         return BufferHandle::Create(buffer);
-    }
-
-    void* Buffer::getSharedHandle() const
-    {
-        return sharedHandle;
     }
 
     ID3D11ShaderResourceView* Buffer::getSRV(Format format, BufferRange range, ResourceType type)

--- a/src/d3d11/d3d11-texture.cpp
+++ b/src/d3d11/d3d11-texture.cpp
@@ -36,6 +36,8 @@ namespace nvrhi::d3d11
         {
         case ObjectTypes::D3D11_Resource:
             return Object(resource);
+        case ObjectTypes::SharedHandle:
+            return Object(resource);
         default:
             return nullptr;
         }
@@ -510,11 +512,6 @@ namespace nvrhi::d3d11
         t->mappedSubresource = UINT(-1);
     }
     
-    void* Texture::getSharedHandle() const
-    {
-        return sharedHandle;
-    }
-
     ID3D11ShaderResourceView* Texture::getSRV(Format format, TextureSubresourceSet subresources, TextureDimension dimension)
     {
         if (format == Format::UNKNOWN)

--- a/src/d3d11/d3d11-texture.cpp
+++ b/src/d3d11/d3d11-texture.cpp
@@ -91,10 +91,15 @@ namespace nvrhi::d3d11
             cpuAccessFlags = D3D11_CPU_ACCESS_WRITE;
 
         UINT miscFlags = 0;
-        if ((d.sharedResourceFlags & SharedResourceFlags::Shared_NTHandle) != 0)
+        bool isShared = false;
+        if ((d.sharedResourceFlags & SharedResourceFlags::Shared_NTHandle) != 0) {
             miscFlags |= D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX | D3D11_RESOURCE_MISC_SHARED_NTHANDLE;
-        else if ((d.sharedResourceFlags & SharedResourceFlags::Shared) != 0)
+            isShared = true;
+        }
+        else if ((d.sharedResourceFlags & SharedResourceFlags::Shared) != 0) {
             miscFlags |= D3D11_RESOURCE_MISC_SHARED;
+            isShared = true;
+        }
 
         RefCountPtr<ID3D11Resource> pResource;
 
@@ -203,9 +208,18 @@ namespace nvrhi::d3d11
         if (!d.debugName.empty())
             SetDebugName(pResource, d.debugName.c_str());
         
+        HANDLE sharedHandle = nullptr;
+        if(isShared)
+        {
+            RefCountPtr<IDXGIResource1 > pDxgiResource1;
+            if (SUCCEEDED(pResource->QueryInterface(IID_PPV_ARGS(&pDxgiResource1))))
+                pDxgiResource1->GetSharedHandle(&sharedHandle);    
+        }
+
         Texture* texture = new Texture(m_Context);
         texture->desc = d;
         texture->resource = pResource;
+        texture->sharedHandle = sharedHandle;
         return TextureHandle::Create(texture);
     }
 
@@ -496,6 +510,11 @@ namespace nvrhi::d3d11
         t->mappedSubresource = UINT(-1);
     }
     
+    void* Texture::getSharedHandle() const
+    {
+        return sharedHandle;
+    }
+
     ID3D11ShaderResourceView* Texture::getSRV(Format format, TextureSubresourceSet subresources, TextureDimension dimension)
     {
         if (format == Format::UNKNOWN)

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -237,8 +237,6 @@ namespace nvrhi::d3d12
         
         const TextureDesc& getDesc() const override { return desc; }
 
-        void* getSharedHandle() const override;
-
         Object getNativeObject(ObjectType objectType) override;
         Object getNativeView(ObjectType objectType, Format format, TextureSubresourceSet subresources, TextureDimension dimension, bool isReadOnlyDSV = false) override;
 
@@ -284,8 +282,6 @@ namespace nvrhi::d3d12
         ~Buffer() override;
         
         const BufferDesc& getDesc() const override { return desc; }
-
-        void* getSharedHandle() const override;
 
         Object getNativeObject(ObjectType objectType) override;
 

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -220,6 +220,7 @@ namespace nvrhi::d3d12
         const D3D12_RESOURCE_DESC resourceDesc;
         RefCountPtr<ID3D12Resource> resource;
         uint8_t planeCount = 1;
+        HANDLE sharedHandle = nullptr;
         HeapHandle heap;
 
         Texture(const Context& context, DeviceResources& resources, TextureDesc desc, const D3D12_RESOURCE_DESC& resourceDesc)
@@ -235,6 +236,8 @@ namespace nvrhi::d3d12
         ~Texture() override;
         
         const TextureDesc& getDesc() const override { return desc; }
+
+        void* getSharedHandle() const override;
 
         Object getNativeObject(ObjectType objectType) override;
         Object getNativeView(ObjectType objectType, Format format, TextureSubresourceSet subresources, TextureDimension dimension, bool isReadOnlyDSV = false) override;
@@ -269,6 +272,7 @@ namespace nvrhi::d3d12
 
         RefCountPtr<ID3D12Fence> lastUseFence;
         uint64_t lastUseFenceValue = 0;
+        HANDLE sharedHandle = nullptr;
 
         Buffer(const Context& context, DeviceResources& resources, BufferDesc desc)
             : BufferStateExtension(this->desc)
@@ -280,6 +284,8 @@ namespace nvrhi::d3d12
         ~Buffer() override;
         
         const BufferDesc& getDesc() const override { return desc; }
+
+        void* getSharedHandle() const override;
 
         Object getNativeObject(ObjectType objectType) override;
 

--- a/src/d3d12/d3d12-buffer.cpp
+++ b/src/d3d12/d3d12-buffer.cpp
@@ -36,6 +36,8 @@ namespace nvrhi::d3d12
         {
         case ObjectTypes::D3D12_Resource:
             return Object(resource);
+        case ObjectTypes::SharedHandle:
+            return Object(sharedHandle);
         default:
             return nullptr;
         }
@@ -294,11 +296,6 @@ namespace nvrhi::d3d12
         buffer->postCreate();
 
         return BufferHandle::Create(buffer);
-    }
-
-    void* Buffer::getSharedHandle() const
-    {
-        return sharedHandle;
     }
 
     void Buffer::createCBV(size_t descriptor, BufferRange range) const

--- a/src/d3d12/d3d12-texture.cpp
+++ b/src/d3d12/d3d12-texture.cpp
@@ -36,6 +36,8 @@ namespace nvrhi::d3d12
         {
         case ObjectTypes::D3D12_Resource:
             return Object(resource);
+        case ObjectTypes::SharedHandle:
+            return Object(sharedHandle);
         default:
             return nullptr;
         }
@@ -431,11 +433,6 @@ namespace nvrhi::d3d12
         texture->postCreate();
 
         return TextureHandle::Create(texture);
-    }
-
-    void* Texture::getSharedHandle() const
-    {
-        return sharedHandle;
     }
 
     void Texture::postCreate()

--- a/src/vulkan/vulkan-allocator.cpp
+++ b/src/vulkan/vulkan-allocator.cpp
@@ -122,7 +122,7 @@ namespace nvrhi::vulkan
         if (enableDeviceAddress)
             allocFlags.flags |= vk::MemoryAllocateFlagBits::eDeviceAddress;
 
-#ifdef WIN32
+#ifdef _WIN32
         const auto handleType = vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32;
 #else
         const auto handleType = vk::ExternalMemoryHandleTypeFlagBits::eOpaqueFd;

--- a/src/vulkan/vulkan-allocator.cpp
+++ b/src/vulkan/vulkan-allocator.cpp
@@ -52,7 +52,8 @@ namespace nvrhi::vulkan
         m_Context.device.getBufferMemoryRequirements(buffer->buffer, &memRequirements);
 
         // allocate memory
-        const vk::Result res = allocateMemory(buffer, memRequirements, pickBufferMemoryProperties(buffer->desc), enableDeviceAddress);
+        const bool enableMemoryExport = (buffer->desc.sharedResourceFlags & SharedResourceFlags::Shared) != 0;
+        const vk::Result res = allocateMemory(buffer, memRequirements, pickBufferMemoryProperties(buffer->desc), enableDeviceAddress, enableMemoryExport);
         CHECK_VK_RETURN(res)
 
         m_Context.device.bindBufferMemory(buffer->buffer, buffer->memory, 0);
@@ -73,7 +74,9 @@ namespace nvrhi::vulkan
 
         // allocate memory
         const vk::MemoryPropertyFlags memProperties = vk::MemoryPropertyFlagBits::eDeviceLocal;
-        const vk::Result res = allocateMemory(texture, memRequirements, memProperties);
+        const bool enableDeviceAddress = false;
+        const bool enableMemoryExport = (texture->desc.sharedResourceFlags & SharedResourceFlags::Shared) != 0;
+        const vk::Result res = allocateMemory(texture, memRequirements, memProperties, enableDeviceAddress, enableMemoryExport);
         CHECK_VK_RETURN(res)
 
         m_Context.device.bindImageMemory(texture->image, texture->memory, 0);
@@ -89,7 +92,8 @@ namespace nvrhi::vulkan
     vk::Result VulkanAllocator::allocateMemory(MemoryResource *res,
                                                vk::MemoryRequirements memRequirements,
                                                vk::MemoryPropertyFlags memPropertyFlags,
-                                                bool enableDeviceAddress) const
+                                                bool enableDeviceAddress,
+                                                bool enableExportMemory) const
     {
         res->managed = true;
 
@@ -117,6 +121,17 @@ namespace nvrhi::vulkan
         auto allocFlags = vk::MemoryAllocateFlagsInfo();
         if (enableDeviceAddress)
             allocFlags.flags |= vk::MemoryAllocateFlagBits::eDeviceAddress;
+
+#ifdef WIN32
+        const auto handleType = vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32;
+#else
+        const auto handleType = vk::ExternalMemoryHandleTypeFlagBits::eOpaqueFd;
+#endif
+        auto exportInfo = vk::ExportMemoryAllocateInfo()
+            .setHandleTypes(handleType);
+
+        if(enableExportMemory)
+            allocFlags.setPNext(&exportInfo);
 
         auto allocInfo = vk::MemoryAllocateInfo()
                             .setAllocationSize(memRequirements.size)

--- a/src/vulkan/vulkan-backend.h
+++ b/src/vulkan/vulkan-backend.h
@@ -281,7 +281,8 @@ namespace nvrhi::vulkan
         vk::Result allocateMemory(MemoryResource* res,
             vk::MemoryRequirements memRequirements,
             vk::MemoryPropertyFlags memPropertyFlags,
-            bool enableDeviceAddress = false) const;
+            bool enableDeviceAddress = false,
+            bool enableExportMemory = false) const;
         void freeMemory(MemoryResource* res) const;
 
     private:
@@ -367,6 +368,8 @@ namespace nvrhi::vulkan
         vk::Image image;
 
         HeapHandle heap;
+
+        void* sharedHandle = nullptr;
         
         // contains subresource views for this texture
         // note that we only create the views that the app uses, and that multiple views may map to the same subresources
@@ -388,6 +391,7 @@ namespace nvrhi::vulkan
 
         ~Texture() override;
         const TextureDesc& getDesc() const override { return desc; }
+        void* getSharedHandle() const override;
         Object getNativeObject(ObjectType objectType) override;
         Object getNativeView(ObjectType objectType, Format format, TextureSubresourceSet subresources, TextureDimension dimension, bool isReadOnlyDSV = false) override;
 
@@ -512,6 +516,7 @@ namespace nvrhi::vulkan
 
         std::vector<BufferVersionItem> versionTracking;
         void* mappedMemory = nullptr;
+        void* sharedHandle = nullptr;
         uint32_t versionSearchStart = 0;
 
         // For staging buffers only
@@ -526,6 +531,7 @@ namespace nvrhi::vulkan
 
         ~Buffer() override;
         const BufferDesc& getDesc() const override { return desc; }
+        void* getSharedHandle() const override;
         Object getNativeObject(ObjectType type) override;
 
     private:

--- a/src/vulkan/vulkan-backend.h
+++ b/src/vulkan/vulkan-backend.h
@@ -391,7 +391,6 @@ namespace nvrhi::vulkan
 
         ~Texture() override;
         const TextureDesc& getDesc() const override { return desc; }
-        void* getSharedHandle() const override;
         Object getNativeObject(ObjectType objectType) override;
         Object getNativeView(ObjectType objectType, Format format, TextureSubresourceSet subresources, TextureDimension dimension, bool isReadOnlyDSV = false) override;
 
@@ -531,7 +530,6 @@ namespace nvrhi::vulkan
 
         ~Buffer() override;
         const BufferDesc& getDesc() const override { return desc; }
-        void* getSharedHandle() const override;
         Object getNativeObject(ObjectType type) override;
 
     private:

--- a/src/vulkan/vulkan-buffer.cpp
+++ b/src/vulkan/vulkan-buffer.cpp
@@ -114,7 +114,7 @@ namespace nvrhi::vulkan
             .setUsage(usageFlags)
             .setSharingMode(vk::SharingMode::eExclusive);
 
-#if WIN32
+#if _WIN32
         const auto handleType = vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32;
 #else
         const auto handleType = vk::ExternalMemoryHandleTypeFlagBits::eOpaqueFd;
@@ -150,7 +150,7 @@ namespace nvrhi::vulkan
 
             if (desc.sharedResourceFlags == SharedResourceFlags::Shared)
             {
-#ifdef WIN32
+#ifdef _WIN32
                 buffer->sharedHandle = m_Context.device.getMemoryWin32HandleKHR({ buffer->memory, vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32 });
 #else
                 buffer->sharedHandle = (void*)m_Context.device.getMemoryFdKHR({ buffer->memory, vk::ExternalMemoryHandleTypeFlagBits::eOpaqueFd });
@@ -508,11 +508,6 @@ namespace nvrhi::vulkan
         }
     }
 
-    void* Buffer::getSharedHandle() const
-    {
-        return sharedHandle;
-    }
-
     Object Buffer::getNativeObject(ObjectType objectType)
     {
         switch (objectType)
@@ -521,6 +516,8 @@ namespace nvrhi::vulkan
             return Object(buffer);
         case ObjectTypes::VK_DeviceMemory:
             return Object(memory);
+        case ObjectTypes::SharedHandle:
+            return Object(sharedHandle);
         default:
             return nullptr;
         }

--- a/src/vulkan/vulkan-texture.cpp
+++ b/src/vulkan/vulkan-texture.cpp
@@ -248,6 +248,16 @@ namespace nvrhi::vulkan
                                 .setSharingMode(vk::SharingMode::eExclusive)
                                 .setSamples(sampleCount)
                                 .setFlags(flags);
+        
+#if WIN32
+        const auto handleType = vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32;
+#else
+        const auto handleType = vk::ExternalMemoryHandleTypeFlagBits::eOpaqueFd;
+#endif
+
+        vk::ExternalMemoryImageCreateInfo externalImage{ handleType };
+        if (desc.sharedResourceFlags == SharedResourceFlags::Shared)
+            texture->imageInfo.setPNext(&externalImage);
     }
 
     TextureSubresourceView& Texture::getSubresourceView(const TextureSubresourceSet& subresource, TextureDimension dimension, TextureSubresourceViewType viewtype)
@@ -322,6 +332,15 @@ namespace nvrhi::vulkan
             res = m_Allocator.allocateTextureMemory(texture);
             ASSERT_VK_OK(res);
             CHECK_VK_FAIL(res)
+
+            if((desc.sharedResourceFlags & SharedResourceFlags::Shared) != 0)
+            {
+#ifdef WIN32
+                texture->sharedHandle = m_Context.device.getMemoryWin32HandleKHR({ texture->memory, vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32 });
+#else
+                texture->sharedHandle = (void*)m_Context.device.getMemoryFdKHR({ texture->memory, vk::ExternalMemoryHandleTypeFlagBits::eOpaqueFd });
+#endif
+            }
 
             m_Context.nameVKObject(texture->memory, vk::DebugReportObjectTypeEXT::eDeviceMemory, desc.debugName.c_str());
         }
@@ -664,6 +683,11 @@ namespace nvrhi::vulkan
         default:
             return nullptr;
         }
+    }
+
+    void* Texture::getSharedHandle() const
+    {
+        return sharedHandle;
     }
 
     uint32_t Texture::getNumSubresources() const

--- a/src/vulkan/vulkan-texture.cpp
+++ b/src/vulkan/vulkan-texture.cpp
@@ -249,7 +249,7 @@ namespace nvrhi::vulkan
                                 .setSamples(sampleCount)
                                 .setFlags(flags);
         
-#if WIN32
+#if _WIN32
         const auto handleType = vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32;
 #else
         const auto handleType = vk::ExternalMemoryHandleTypeFlagBits::eOpaqueFd;
@@ -335,7 +335,7 @@ namespace nvrhi::vulkan
 
             if((desc.sharedResourceFlags & SharedResourceFlags::Shared) != 0)
             {
-#ifdef WIN32
+#ifdef _WIN32
                 texture->sharedHandle = m_Context.device.getMemoryWin32HandleKHR({ texture->memory, vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32 });
 #else
                 texture->sharedHandle = (void*)m_Context.device.getMemoryFdKHR({ texture->memory, vk::ExternalMemoryHandleTypeFlagBits::eOpaqueFd });
@@ -656,6 +656,8 @@ namespace nvrhi::vulkan
             return Object(image);
         case ObjectTypes::VK_DeviceMemory:
             return Object(memory);
+        case ObjectTypes::SharedHandle:
+            return Object(sharedHandle);
         default:
             return nullptr;
         }
@@ -683,11 +685,6 @@ namespace nvrhi::vulkan
         default:
             return nullptr;
         }
-    }
-
-    void* Texture::getSharedHandle() const
-    {
-        return sharedHandle;
     }
 
     uint32_t Texture::getNumSubresources() const

--- a/tools/shaderCompiler/shaderCompiler.cpp
+++ b/tools/shaderCompiler/shaderCompiler.cpp
@@ -188,7 +188,7 @@ bool getHierarchicalUpdateTime(const fs::path& rootFilePath, list<fs::path>& cal
 string buildCompilerCommandLine(const CompilerOptions& options, const fs::path& shaderFile, const fs::path& outputFile)
 {
 	std::ostringstream ss;
-#ifdef WIN32
+#ifdef _WIN32
 	ss << "%COMPILER% ";
 #else
 	ss << "$COMPILER ";


### PR DESCRIPTION
Concept PR to extend existing shared resource creation.

Adding shared resource creation for Vulkan backend.
Adding method to access shared handle. (Could be also done with NativeObject?)

Fence/Semaphore sharing would still be needed.