### PR TITLE
Added dynamic stencil reference to command list

### DIFF
--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -2536,6 +2536,7 @@ namespace nvrhi
         virtual void setPushConstants(const void* data, size_t byteSize) = 0;
 
         virtual void setGraphicsState(const GraphicsState& state) = 0;
+        virtual void setStencilRefValue(uint8_t value) = 0;
         virtual void draw(const DrawArguments& args) = 0;
         virtual void drawIndexed(const DrawArguments& args) = 0;
         virtual void drawIndirect(uint32_t offsetBytes, uint32_t drawCount = 1) = 0;

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -306,6 +306,7 @@ namespace nvrhi::d3d11
         void setPushConstants(const void* data, size_t byteSize) override;
 
         void setGraphicsState(const GraphicsState& state) override;
+        void setStencilRefValue(uint8_t value) override;
         void draw(const DrawArguments& args) override;
         void drawIndexed(const DrawArguments& args) override;
         void drawIndirect(uint32_t offsetBytes, uint32_t drawCount) override;

--- a/src/d3d11/d3d11-graphics.cpp
+++ b/src/d3d11/d3d11-graphics.cpp
@@ -359,6 +359,12 @@ namespace nvrhi::d3d11
         }
     }
 
+    void CommandList::setStencilRefValue(uint8_t value)
+    {
+        GraphicsPipeline* pipeline = checked_cast<GraphicsPipeline*>(m_CurrentGraphicsPipeline.Get());
+        m_Context.immediateContext->OMSetDepthStencilState(pipeline->pDepthStencilState, value);
+    }
+
     void CommandList::draw(const DrawArguments& args)
     {
         m_Context.immediateContext->DrawInstanced(args.vertexCount, args.instanceCount, args.startVertexLocation, args.startInstanceLocation);

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -893,6 +893,7 @@ namespace nvrhi::d3d12
         void setPushConstants(const void* data, size_t byteSize) override;
 
         void setGraphicsState(const GraphicsState& state) override;
+        void setStencilRefValue(uint8_t value) override;
         void draw(const DrawArguments& args) override;
         void drawIndexed(const DrawArguments& args) override;
         void drawIndirect(uint32_t offsetBytes, uint32_t drawCount) override;

--- a/src/d3d12/d3d12-graphics.cpp
+++ b/src/d3d12/d3d12-graphics.cpp
@@ -477,6 +477,11 @@ namespace nvrhi::d3d12
         m_CurrentGraphicsState = state;
     }
 
+    void CommandList::setStencilRefValue(uint8_t value)
+    {
+        m_ActiveCommandList->commandList->OMSetStencilRef(value);
+    }
+
     void CommandList::unbindShadingRateState()
     {
         if (m_CurrentGraphicsStateValid && m_CurrentGraphicsState.shadingRateState.enabled)

--- a/src/validation/validation-backend.h
+++ b/src/validation/validation-backend.h
@@ -167,6 +167,7 @@ namespace nvrhi::validation
         void setPushConstants(const void* data, size_t byteSize) override;
 
         void setGraphicsState(const GraphicsState& state) override;
+        void setStencilRefValue(uint8_t value) override;
         void draw(const DrawArguments& args) override;
         void drawIndexed(const DrawArguments& args) override;
         void drawIndirect(uint32_t offsetBytes, uint32_t drawCount) override;

--- a/src/validation/validation-commandlist.cpp
+++ b/src/validation/validation-commandlist.cpp
@@ -645,6 +645,39 @@ namespace nvrhi::validation
         m_CurrentGraphicsState = state;
     }
 
+    void CommandListWrapper::setStencilRefValue(uint8_t value)
+    {
+        if (!requireOpenState())
+            return;
+
+        if (!requireType(CommandQueue::Graphics, "draw"))
+            return;
+
+        if (!m_GraphicsStateSet)
+        {
+            error("Graphics state is not set before a draw call.\n"
+                  "Note that setting compute state invalidates the graphics state.");
+            return;
+        }
+
+        const auto& dsDesc = m_CurrentGraphicsState.pipeline->getDesc().renderState.depthStencilState;
+
+        if (!dsDesc.stencilEnable)
+        {
+            error("setStencilRefValue: stencil is not enabled");
+            return;
+        }
+
+        if (!dsDesc.stencilReadMask &&
+            !dsDesc.stencilWriteMask)
+        {
+            error("setStencilRefValue: stencil read and write masks are both 0");
+            return;
+        }
+
+        m_CommandList->setStencilRefValue(value);
+    }
+
     void CommandListWrapper::draw(const DrawArguments& args)
     {
         if (!requireOpenState())

--- a/src/vulkan/vulkan-backend.h
+++ b/src/vulkan/vulkan-backend.h
@@ -1183,6 +1183,7 @@ namespace nvrhi::vulkan
         void setPushConstants(const void* data, size_t byteSize) override;
 
         void setGraphicsState(const GraphicsState& state) override;
+        void setStencilRefValue(uint8_t value) override;
         void draw(const DrawArguments& args) override;
         void drawIndexed(const DrawArguments& args) override;
         void drawIndirect(uint32_t offsetBytes, uint32_t drawCount) override;

--- a/src/vulkan/vulkan-graphics.cpp
+++ b/src/vulkan/vulkan-graphics.cpp
@@ -560,12 +560,12 @@ namespace nvrhi::vulkan
         vk::DynamicState dynamicStates[4] = {
             vk::DynamicState::eViewport,
             vk::DynamicState::eScissor,
+            vk::DynamicState::eStencilReference,
             vk::DynamicState::eBlendConstants,
-            vk::DynamicState::eFragmentShadingRateKHR
         };
 
         auto dynamicStateInfo = vk::PipelineDynamicStateCreateInfo()
-            .setDynamicStateCount(pso->usesBlendConstants ? 3 : 2)
+            .setDynamicStateCount(pso->usesBlendConstants ? 4 : 3)
             .setPDynamicStates(dynamicStates);
 
         auto pipelineInfo = vk::GraphicsPipelineCreateInfo()
@@ -784,6 +784,11 @@ namespace nvrhi::vulkan
         m_CurrentMeshletState = MeshletState();
         m_CurrentRayTracingState = rt::State();
         m_AnyVolatileBufferWrites = false;
+    }
+
+    void CommandList::setStencilRefValue(uint8_t value)
+    {
+        m_CurrentCmdBuf->cmdBuf.setStencilReference(vk::StencilFaceFlagBits::eFrontAndBack, value);
     }
 
     void CommandList::updateGraphicsVolatileBuffers()

--- a/src/vulkan/vulkan-meshlets.cpp
+++ b/src/vulkan/vulkan-meshlets.cpp
@@ -185,14 +185,15 @@ namespace nvrhi::vulkan
 
         pso->usesBlendConstants = blendState.usesConstantColor(uint32_t(fb->desc.colorAttachments.size()));
         
-        vk::DynamicState dynamicStates[3] = {
+        vk::DynamicState dynamicStates[4] = {
             vk::DynamicState::eViewport,
             vk::DynamicState::eScissor,
+            vk::DynamicState::eStencilReference,
             vk::DynamicState::eBlendConstants
         };
 
         auto dynamicStateInfo = vk::PipelineDynamicStateCreateInfo()
-            .setDynamicStateCount(pso->usesBlendConstants ? 3 : 2)
+            .setDynamicStateCount(pso->usesBlendConstants ? 4 : 3)
             .setPDynamicStates(dynamicStates);
 
         auto pipelineInfo = vk::GraphicsPipelineCreateInfo()


### PR DESCRIPTION
It's convenient to dynamically set stencil reference rather than recompiling the same pipelinestate object.