### PR TITLE
Fixes for clang type error and logical expression warning

### DIFF
--- a/src/validation/validation-device.cpp
+++ b/src/validation/validation-device.cpp
@@ -1179,7 +1179,7 @@ namespace nvrhi::validation
         }
 
         const GraphicsAPI graphicsApi = m_Device->getGraphicsAPI();
-        if (!(graphicsApi == GraphicsAPI::D3D12 || graphicsApi == GraphicsAPI::VULKAN && desc.registerSpaceIsDescriptorSet))
+        if (!(graphicsApi == GraphicsAPI::D3D12 || (graphicsApi == GraphicsAPI::VULKAN && desc.registerSpaceIsDescriptorSet)))
         {
             if (desc.registerSpace != 0)
             {

--- a/src/vulkan/vulkan-resource-bindings.cpp
+++ b/src/vulkan/vulkan-resource-bindings.cpp
@@ -452,7 +452,7 @@ namespace nvrhi::vulkan
                 auto vkformat = nvrhi::vulkan::convertFormat(format);
                 const auto range = binding.range.resolve(buffer->desc);
 
-                uint64_t viewInfoHash = 0;
+                size_t viewInfoHash = 0;
                 nvrhi::hash_combine(viewInfoHash, range.byteOffset);
                 nvrhi::hash_combine(viewInfoHash, range.byteSize);
                 nvrhi::hash_combine(viewInfoHash, (uint64_t)vkformat);
@@ -771,7 +771,7 @@ namespace nvrhi::vulkan
                     auto vkformat = nvrhi::vulkan::convertFormat(binding.format);
 
                     const auto range = binding.range.resolve(buffer->desc);
-                    uint64_t viewInfoHash = 0;
+                    size_t viewInfoHash = 0;
                     nvrhi::hash_combine(viewInfoHash, range.byteOffset);
                     nvrhi::hash_combine(viewInfoHash, range.byteSize);
                     nvrhi::hash_combine(viewInfoHash, (uint64_t)vkformat);


### PR DESCRIPTION
Fixes #46

Solves (Apple) clang blocking error (wrong type) and clang warning (logical expression precedence).