### PR TITLE
fix a small index error in bindComputeResourceSets

### DIFF
--- a/src/d3d11/d3d11-resource-bindings.cpp
+++ b/src/d3d11/d3d11-resource-bindings.cpp
@@ -416,7 +416,7 @@ void CommandList::bindComputeResourceSets(
             if (setsToBind[i])
                 for (uint32_t j = 0; j < uint32_t(setsToUnbind.size()); j++)
                 {
-                    BindingSet* setToBind = checked_cast<BindingSet*>(setsToBind[j]);
+                    BindingSet* setToBind = checked_cast<BindingSet*>(setsToBind[i]);
                     BindingSet* setToUnbind = checked_cast<BindingSet*>(setsToUnbind[j]);
 
                     if (setToUnbind && setToBind->isSupersetOf(*setToUnbind) && setToUnbind->maxUAVSlot < setToUnbind->minUAVSlot)


### PR DESCRIPTION
`SetToBind` should belongs to outer loop, which uses index `i` instead of `j`