### PR TITLE
Fixing static_vector memory leak in validatePipelineBindingLayouts

### DIFF
--- a/include/nvrhi/common/containers.h
+++ b/include/nvrhi/common/containers.h
@@ -138,12 +138,12 @@ struct static_vector : private std::array<T, _max_elements>
         if (current_size > new_size)
         {
             for (size_type i = new_size; i < current_size; i++)
-                (data() + i)->~T();
+                *(data() + i) = T{};
         }
         else
         {
             for (size_type i = current_size; i < new_size; i++)
-                new (data() + i) T();
+                *(data() + i) = T{};
         }
 
         current_size = new_size;


### PR DESCRIPTION
DeviceWrapper::validatePipelineBindingLayouts will leak memory allocated for bindingsPerLayout & duplicatesPerLayout's members due to the way static_vector's resize is implemented, which assumes that all std::array's elements are in an uninitialized state by default.

Changing static_vector to use assignment in resize instead of placement new/delete fixes the issue without adding a bunch of extra plumbing or running the destructor over each element in static_vector's constructor.