### PR TITLE
Fix compilation with /std:c++20 and newer on MSVC

### DIFF
--- a/src/vulkan/vulkan-device.cpp
+++ b/src/vulkan/vulkan-device.cpp
@@ -22,6 +22,7 @@
 
 #include "vulkan-backend.h"
 #include <unordered_map>
+#include <sstream>
 
 #include <nvrhi/common/misc.h>
 

--- a/src/vulkan/vulkan-raytracing.cpp
+++ b/src/vulkan/vulkan-raytracing.cpp
@@ -22,6 +22,7 @@
 
 #include "vulkan-backend.h"
 #include <nvrhi/common/misc.h>
+#include <sstream>
 
 namespace nvrhi::vulkan
 {

--- a/src/vulkan/vulkan-resource-bindings.cpp
+++ b/src/vulkan/vulkan-resource-bindings.cpp
@@ -22,6 +22,7 @@
 
 #include "vulkan-backend.h"
 #include <nvrhi/common/misc.h>
+#include <sstream>
 
 namespace nvrhi::vulkan
 {


### PR DESCRIPTION
When compiling for C++20 or newer on MSVC (and possibly other compilers), `<sstream>` is not automatically included with the Vulkan headers and NVRHI fails to compile. This is because `vulkan_to_string.hpp` uses `<format>` instead of `<sstream>` when it's supported.

This pull request simply includes `<sstream>` in every translation unit where `std::stringstream` is needed.