### PR TITLE
Typos and GCC warning fixes

### DIFF
--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -757,7 +757,7 @@ namespace nvrhi
         Pixel           = 0x0010,
         Amplification   = 0x0040,
         Mesh            = 0x0080,
-        AllGraphics     = 0x00FE,
+        AllGraphics     = 0x00DF,
 
         RayGeneration   = 0x0100,
         AnyHit          = 0x0200,

--- a/src/validation/validation-commandlist.cpp
+++ b/src/validation/validation-commandlist.cpp
@@ -1263,6 +1263,7 @@ namespace nvrhi::validation
                     {
                     case Format::RG32_FLOAT:
                     case Format::RGB32_FLOAT:
+                    case Format::RGBA32_FLOAT:
                     case Format::RG16_FLOAT:
                     case Format::RGBA16_FLOAT:
                     case Format::RG16_SNORM:
@@ -1278,7 +1279,7 @@ namespace nvrhi::validation
                     default: {
                         std::stringstream ss;
                         ss << "BLAS " << utils::DebugNameToString(as->getDesc().debugName) << " build geometry " << i
-                            << " has unsupported vertex format: " << utils::FormatToString(triangles.indexFormat);
+                            << " has unsupported vertex format: " << utils::FormatToString(triangles.vertexFormat);
                         error(ss.str());
                         return;
                     }

--- a/src/vulkan/vulkan-device.cpp
+++ b/src/vulkan/vulkan-device.cpp
@@ -283,7 +283,7 @@ namespace nvrhi::vulkan
         try {
             m_Context.device.waitIdle();
         }
-        catch (vk::DeviceLostError e)
+        catch (vk::DeviceLostError &e)
         {
             return false;
         }

--- a/src/vulkan/vulkan-queue.cpp
+++ b/src/vulkan/vulkan-queue.cpp
@@ -170,7 +170,7 @@ namespace nvrhi::vulkan
         try {
             m_Queue.submit(submitInfo);
         }
-        catch (vk::DeviceLostError e)
+        catch (vk::DeviceLostError &e)
         {
             m_Context.messageCallback->message(MessageSeverity::Error, "Device Removed!");
         }


### PR DESCRIPTION
- Add RGBA32F vertex format support in BLAS, and fix the error message when a format isn't supported.
- `ShaderType::AllGraphics` mask previously included `Compute` and excluded `Vertex`.
- GCC 14.2 complains about catching exceptions by value.