### PR TITLE
Add GetRefCount() API to IResource and RefCounter for debugging and tracking

### DIFF
--- a/include/nvrhi/common/resource.h
+++ b/include/nvrhi/common/resource.h
@@ -109,6 +109,7 @@ namespace nvrhi
     public:
         virtual unsigned long AddRef() = 0;
         virtual unsigned long Release() = 0;
+        virtual unsigned long GetRefCount() = 0;
 
         // Returns a native object or interface, for example ID3D11Device*, or nullptr if the requested interface is unavailable.
         // Does *not* AddRef the returned interface.
@@ -386,6 +387,11 @@ namespace nvrhi
                 delete this;
             }
             return result;
+        }
+
+        virtual unsigned long GetRefCount() override 
+        {
+            return m_refCount.load();
         }
     };
 


### PR DESCRIPTION
This is useful when working with bindings Cache where resources may become outdated. 
The API makes it easier to detect when a resource is no longer referenced and can be safely removed.

Example:
https://github.com/NVIDIA-RTX/Donut/blob/main/src/app/imgui_nvrhi.cpp#L242

this can be fix like
```
for (auto it = bindingsCache.begin(); it != bindingsCache.end();)
{
    if (it->first->GetRefCount() == 1)
        it = bindingsCache.erase(it);
    else
        ++it;
}
```