### PR TITLE
Allow building with Vulkan-Headers past 1.4.318

### DIFF
--- a/src/vulkan/vulkan-constants.cpp
+++ b/src/vulkan/vulkan-constants.cpp
@@ -899,10 +899,17 @@ namespace nvrhi::vulkan
             return vk::ComponentTypeKHR::eUint64;
         case coopvec::DataType::SInt64:
             return vk::ComponentTypeKHR::eSint64;
+#if (VK_HEADER_VERSION >= 318)
+        case coopvec::DataType::FloatE4M3:
+            return vk::ComponentTypeKHR::eFloatE4M3;
+        case coopvec::DataType::FloatE5M2:
+            return vk::ComponentTypeKHR::eFloatE5M2;
+#else
         case coopvec::DataType::FloatE4M3:
             return vk::ComponentTypeKHR::eFloatE4M3NV;
         case coopvec::DataType::FloatE5M2:
             return vk::ComponentTypeKHR::eFloatE5M2NV;
+#endif
         case coopvec::DataType::Float16:
             return vk::ComponentTypeKHR::eFloat16;
         case coopvec::DataType::BFloat16:
@@ -941,10 +948,17 @@ namespace nvrhi::vulkan
             return coopvec::DataType::UInt64;
         case vk::ComponentTypeKHR::eSint64:
             return coopvec::DataType::SInt64;
+#if (VK_HEADER_VERSION >= 318)
+        case vk::ComponentTypeKHR::eFloatE4M3:
+            return coopvec::DataType::FloatE4M3;
+        case vk::ComponentTypeKHR::eFloatE5M2:
+            return coopvec::DataType::FloatE5M2;
+#else
         case vk::ComponentTypeKHR::eFloatE4M3NV:
             return coopvec::DataType::FloatE4M3;
         case vk::ComponentTypeKHR::eFloatE5M2NV:
             return coopvec::DataType::FloatE5M2;
+#endif
         case vk::ComponentTypeKHR::eFloat16:
             return coopvec::DataType::Float16;
         case vk::ComponentTypeKHR::eBfloat16:


### PR DESCRIPTION
As of Vulkan 1.4.318 ( KhronosGroup/Vulkan-Headers@b39ab38 ), `vk::ComponentTypeKHR::eFloatE4M3NV` and `vk::ComponentTypeKHR::eFloatE5M2NV` were renamed to `eFloatE4M3` and `eFloatE5M2`.