### PR TITLE
Compare current bindings with the correct state.

### DIFF
--- a/src/vulkan/vulkan-graphics.cpp
+++ b/src/vulkan/vulkan-graphics.cpp
@@ -563,7 +563,7 @@ namespace nvrhi::vulkan
         m_CurrentPipelineLayout = pso->pipelineLayout;
         m_CurrentPushConstantsVisibility = pso->pushConstantVisibility;
 
-        if (arraysAreDifferent(m_CurrentComputeState.bindings, state.bindings) || m_AnyVolatileBufferWrites)
+        if (arraysAreDifferent(m_CurrentGraphicsState.bindings, state.bindings) || m_AnyVolatileBufferWrites)
         {
             bindBindingSets(vk::PipelineBindPoint::eGraphics, pso->pipelineLayout, state.bindings, pso->descriptorSetIdxToBindingIdx);
         }


### PR DESCRIPTION
In setGraphicsState the bindings were compared against the current compute state (which promptly gets reset after the function call) instead of the graphics state. This resulted in descriptor sets being bound again even if they are the exact same descriptor sets from the last call.