### PR TITLE
Add support for DX12/Vulkan drawIndexedIndirectCount

### DIFF
--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -2665,6 +2665,9 @@ namespace nvrhi
 
         IBuffer* indirectParams = nullptr;
 
+        IBuffer* indirectCountBuffer = nullptr;
+        uint32_t indirectCountOffset = 0;
+
         GraphicsState& setPipeline(IGraphicsPipeline* value) { pipeline = value; return *this; }
         GraphicsState& setFramebuffer(IFramebuffer* value) { framebuffer = value; return *this; }
         GraphicsState& setViewport(const ViewportState& value) { viewport = value; return *this; }
@@ -2675,6 +2678,7 @@ namespace nvrhi
         GraphicsState& addVertexBuffer(const VertexBufferBinding& value) { vertexBuffers.push_back(value); return *this; }
         GraphicsState& setIndexBuffer(const IndexBufferBinding& value) { indexBuffer = value; return *this; }
         GraphicsState& setIndirectParams(IBuffer* value) { indirectParams = value; return *this; }
+        GraphicsState& setIndirectCountBuffer(IBuffer* buf, uint32_t offset = 0) { indirectCountBuffer = buf; indirectCountOffset = offset; return *this; }
     };
 
     struct DrawArguments
@@ -3286,7 +3290,14 @@ namespace nvrhi
         // - DX12: Maps to ExecuteIndirect with a predefined signature.
         // - Vulkan: Maps to vkCmdDrawIndexedIndirect.
         virtual void drawIndexedIndirect(uint32_t offsetBytes, uint32_t drawCount = 1) = 0;
-        
+
+		// Draws primitives with indexed vertices using the parameters provided in the indirect arguments buffer.
+		// The draw count is read from the indirectCountBuffer specified in setGraphicsState(...).
+		// - DX11: Not supported (falls back to maxDrawCount draws).
+		// - DX12: Maps to ExecuteIndirect with pCountBuffer parameter.
+		// - Vulkan: Maps to vkCmdDrawIndexedIndirectCount.
+		virtual void drawIndexedIndirectCount(uint32_t offsetBytes, uint32_t maxDrawCount) = 0;
+
         // Sets the specified compute state on the command list.
         // The state includes the pipeline (or individual shaders on DX11) and all resources bound to it.
         // See the members of ComputeState for more information.

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -323,6 +323,7 @@ namespace nvrhi::d3d11
         void drawIndexed(const DrawArguments& args) override;
         void drawIndirect(uint32_t offsetBytes, uint32_t drawCount) override;
         void drawIndexedIndirect(uint32_t offsetBytes, uint32_t drawCount) override;
+        void drawIndexedIndirectCount(uint32_t offsetBytes, uint32_t maxDrawCount) override;
 
         void setComputeState(const ComputeState& state) override;
         void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) override;

--- a/src/d3d11/d3d11-graphics.cpp
+++ b/src/d3d11/d3d11-graphics.cpp
@@ -414,6 +414,12 @@ namespace nvrhi::d3d11
         }
     }
 
+    void CommandList::drawIndexedIndirectCount(uint32_t offsetBytes, uint32_t maxDrawCount)
+    {
+        // D3D11 doesn't support count buffers - fall back to default drawIndexedIndirect behavior
+        drawIndexedIndirect(offsetBytes, maxDrawCount);
+    }
+
     ID3D11BlendState* Device::getBlendState(const BlendState& blendState)
     {
         size_t hash = 0;

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -979,6 +979,7 @@ namespace nvrhi::d3d12
         void drawIndexed(const DrawArguments& args) override;
         void drawIndirect(uint32_t offsetBytes, uint32_t drawCount) override;
         void drawIndexedIndirect(uint32_t offsetBytes, uint32_t drawCount) override;
+        void drawIndexedIndirectCount(uint32_t offsetBytes, uint32_t maxDrawCount) override;
 
         void setComputeState(const ComputeState& state) override;
         void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) override;

--- a/src/d3d12/d3d12-graphics.cpp
+++ b/src/d3d12/d3d12-graphics.cpp
@@ -580,7 +580,26 @@ namespace nvrhi::d3d12
 
         m_ActiveCommandList->commandList->ExecuteIndirect(m_Context.drawIndexedIndirectSignature, drawCount, indirectParams->resource, offsetBytes, nullptr, 0);
     }
-    
+
+    void CommandList::drawIndexedIndirectCount(uint32_t offsetBytes, uint32_t maxDrawCount)
+    {
+        Buffer* indirectParams = checked_cast<Buffer*>(m_CurrentGraphicsState.indirectParams);
+        Buffer* countBuf = checked_cast<Buffer*>(m_CurrentGraphicsState.indirectCountBuffer);
+        assert(indirectParams);
+        assert(countBuf);
+
+        updateGraphicsVolatileBuffers();
+
+        m_ActiveCommandList->commandList->ExecuteIndirect(
+            m_Context.drawIndexedIndirectSignature,
+            maxDrawCount,
+            indirectParams->resource,
+            offsetBytes,
+            countBuf->resource,
+            m_CurrentGraphicsState.indirectCountOffset
+        );
+    }
+
     DX12_ViewportState convertViewportState(const RasterState& rasterState, const FramebufferInfoEx& framebufferInfo, const ViewportState& vpState)
     {
         DX12_ViewportState ret;

--- a/src/validation/validation-backend.h
+++ b/src/validation/validation-backend.h
@@ -223,6 +223,7 @@ namespace nvrhi::validation
         void drawIndexed(const DrawArguments& args) override;
         void drawIndirect(uint32_t offsetBytes, uint32_t drawCount) override;
         void drawIndexedIndirect(uint32_t offsetBytes, uint32_t drawCount) override;
+        void drawIndexedIndirectCount(uint32_t offsetBytes, uint32_t maxDrawCount) override;
 
         void setComputeState(const ComputeState& state) override;
         void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) override;

--- a/src/validation/validation-commandlist.cpp
+++ b/src/validation/validation-commandlist.cpp
@@ -762,6 +762,39 @@ namespace nvrhi::validation
         m_CommandList->drawIndexedIndirect(offsetBytes, drawCount);
     }
 
+    void CommandListWrapper::drawIndexedIndirectCount(uint32_t offsetBytes, uint32_t maxDrawCount)
+    {
+        if (!requireOpenState())
+            return;
+
+        if (!requireType(CommandQueue::Graphics, "drawIndexedIndirectCount"))
+            return;
+
+        if (!m_GraphicsStateSet)
+        {
+            error("Graphics state is not set before a drawIndexedIndirectCount call.\n"
+                "Note that setting compute state invalidates the graphics state.");
+            return;
+        }
+
+        if (!m_CurrentGraphicsState.indirectParams)
+        {
+            error("Indirect params buffer is not set before a drawIndexedIndirectCount call.");
+            return;
+        }
+
+        if (!m_CurrentGraphicsState.indirectCountBuffer)
+        {
+            error("Indirect count buffer is not set before a drawIndexedIndirectCount call.");
+            return;
+        }
+
+        if (!validatePushConstants("graphics", "setGraphicsState"))
+            return;
+
+        m_CommandList->drawIndexedIndirectCount(offsetBytes, maxDrawCount);
+    }
+
     void CommandListWrapper::setComputeState(const ComputeState& state)
     {
         if (!requireOpenState())

--- a/src/vulkan/vulkan-backend.h
+++ b/src/vulkan/vulkan-backend.h
@@ -1239,6 +1239,7 @@ namespace nvrhi::vulkan
         void drawIndexed(const DrawArguments& args) override;
         void drawIndirect(uint32_t offsetBytes, uint32_t drawCount) override;
         void drawIndexedIndirect(uint32_t offsetBytes, uint32_t drawCount) override;
+        void drawIndexedIndirectCount(uint32_t offsetBytes, uint32_t maxDrawCount) override;
 
         void setComputeState(const ComputeState& state) override;
         void dispatch(uint32_t groupsX, uint32_t groupsY = 1, uint32_t groupsZ = 1) override;

--- a/src/vulkan/vulkan-graphics.cpp
+++ b/src/vulkan/vulkan-graphics.cpp
@@ -713,4 +713,25 @@ namespace nvrhi::vulkan
         m_CurrentCmdBuf->cmdBuf.drawIndexedIndirect(indirectParams->buffer, offsetBytes, drawCount, sizeof(DrawIndexedIndirectArguments));
     }
 
+    void CommandList::drawIndexedIndirectCount(uint32_t offsetBytes, uint32_t maxDrawCount)
+    {
+        assert(m_CurrentCmdBuf);
+
+        updateGraphicsVolatileBuffers();
+
+        Buffer* indirectParams = checked_cast<Buffer*>(m_CurrentGraphicsState.indirectParams);
+        Buffer* countBuf = checked_cast<Buffer*>(m_CurrentGraphicsState.indirectCountBuffer);
+        assert(indirectParams);
+        assert(countBuf);
+
+        m_CurrentCmdBuf->cmdBuf.drawIndexedIndirectCount(
+            indirectParams->buffer,
+            offsetBytes,
+            countBuf->buffer,
+            m_CurrentGraphicsState.indirectCountOffset,
+            maxDrawCount,
+            sizeof(DrawIndexedIndirectArguments)
+        );
+    }
+
 } // namespace nvrhi::vulkan


### PR DESCRIPTION
Worked on this feature for OpenXRay because original drawIndexedIndirect added overhead- since it was still issuing empty draw calls for culled objects. To fix this, added support to execute based on the visible count from countBuffer for dx12, with stub for dx11.

<img width="2560" height="1009" alt="27b76c31a6ba898596a10fc7226559c1" src="https://github.com/user-attachments/assets/eeca50b0-d43b-4225-89dc-72900a729b2a" />
