### PR TITLE
Don't end Vulkan render pass for volatile buffers in CommandList::writeBuffer

### DIFF
--- a/src/vulkan/vulkan-buffer.cpp
+++ b/src/vulkan/vulkan-buffer.cpp
@@ -448,8 +448,6 @@ namespace nvrhi::vulkan
 
         assert(m_CurrentCmdBuf);
 
-        endRenderPass();
-
         m_CurrentCmdBuf->referencedResources.push_back(buffer);
 
         if (buffer->desc.isVolatile)
@@ -460,6 +458,10 @@ namespace nvrhi::vulkan
             
             return;
         }
+
+        // Per Vulkan spec, vkCmdUpdateBuffer is only allowed outside of a render pass, so end it here.
+        // Note that writeVolatileBuffer above is permitted so don't end the render pass for that case.
+        endRenderPass();
 
         const size_t vkCmdUpdateBufferLimit = 65536;
 


### PR DESCRIPTION
Ending the Vulkan render pass is not required for writing to volatile buffers.  This PR moves the `endRenderPass()` call inside `CommandList::writeBuffer` from before `writeVolatileBuffer()` to after, but before `vkCmdUpdateBuffer()`.

This has a very positive performance impact for macOS platforms (using MoltenVK, KosmicKrisp) where ending the render pass triggers Metal command encoding (expensive).  By reducing the number of render passes (especially for volatile constant buffers) runtime performance is improved.  This change should not degrade performance on other platforms.

Fixes #98.