### PR TITLE
Introducing a CommandListLifetimeTracker to enable work submission from multiple threads

### DIFF
--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -3087,6 +3087,7 @@ namespace nvrhi
     };
     
     class IDevice;
+    class ICommandListLifetimeTracker;
 
     struct CommandListParameters
     {
@@ -3107,13 +3108,41 @@ namespace nvrhi
         // COPY and COMPUTE queues have limited subsets of methods available.
         CommandQueue queueType = CommandQueue::Graphics;
 
+        // Optional external lifetime tracker to use for this command list.
+        // If left nullptr, lifetime will be tracked by the device.
+        ICommandListLifetimeTracker* lifetimeTracker = nullptr;
+
         CommandListParameters& setEnableImmediateExecution(bool value) { enableImmediateExecution = value; return *this; }
         CommandListParameters& setUploadChunkSize(size_t value) { uploadChunkSize = value; return *this; }
         CommandListParameters& setScratchChunkSize(size_t value) { scratchChunkSize = value; return *this; }
         CommandListParameters& setScratchMaxMemory(size_t value) { scratchMaxMemory = value; return *this; }
         CommandListParameters& setQueueType(CommandQueue value) { queueType = value; return *this; }
+        CommandListParameters& setLifetimeTracker(ICommandListLifetimeTracker* value) { lifetimeTracker = value; return *this; }
     };
-    
+
+    //////////////////////////////////////////////////////////////////////////
+    // ICommandListLifetimeTracker
+    //////////////////////////////////////////////////////////////////////////
+
+    // Manages the lifetime of command list objects in a way that is scalable for multithreading.
+    // Each thread that submits work to the GPU (calls IDevice::executeCommandList[s]) should own its own command list tracker
+    // for each queue it submits work to.
+    // - DX11: Multithreaded work submission is not supported.
+    // - DX12: A lifetime tracker can be optionally specified when creating a command list. After submitting a command list,
+	//   internal command lists and their referenced resources will be held by the lifetime tracker until work has finished
+	//   execution on the GPU. Execute runGarbageCollection frequently to poll the GPU and release resources when possible.
+    //   If no lifetime tracker is specified, the Device will add the command list to its own internal lifetime trackers.
+    // - Vulkan: Not yet implemented.
+    class ICommandListLifetimeTracker : public IResource
+    {
+    public:
+        // Releases any command lists that have finished executing on the GPU.
+        // This should be called frequently, e.g. once per frame, once per simulation step, etc.
+        virtual void runGarbageCollection() = 0;
+    };
+
+    typedef RefCountPtr<ICommandListLifetimeTracker> CommandListLifetimeTrackerHandle;
+
     //////////////////////////////////////////////////////////////////////////
     // ICommandList
     //////////////////////////////////////////////////////////////////////////
@@ -3684,6 +3713,8 @@ namespace nvrhi
         virtual void queueWaitForCommandList(CommandQueue waitQueue, CommandQueue executionQueue, uint64_t instance) = 0;
         // returns true if the wait completes successfully, false if detecting a problem (e.g. device removal)
         virtual bool waitForIdle() = 0;
+
+        virtual CommandListLifetimeTrackerHandle createCommandListLifetimeTracker(CommandQueue executionQueue) = 0;
 
         // Releases the resources that were referenced in the command lists that have finished executing.
         // IMPORTANT: Call this method at least once per frame.

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -521,6 +521,7 @@ namespace nvrhi::d3d11
         uint64_t executeCommandLists(ICommandList* const* pCommandLists, size_t numCommandLists, CommandQueue executionQueue = CommandQueue::Graphics) override { (void)pCommandLists; (void)numCommandLists; (void)executionQueue; return 0; }
         void queueWaitForCommandList(CommandQueue waitQueue, CommandQueue executionQueue, uint64_t instance) override { (void)waitQueue; (void)executionQueue; (void)instance; }
         bool waitForIdle() override;
+        CommandListLifetimeTrackerHandle createCommandListLifetimeTracker(CommandQueue executionQueue) override;
         void runGarbageCollection() override { }
         bool queryFeatureSupport(Feature feature, void* pInfo = nullptr, size_t infoSize = 0) override;
         FormatSupport queryFormatSupport(Format format) override;

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -362,6 +362,13 @@ namespace nvrhi::d3d11
         return true;
     }
 
+    CommandListLifetimeTrackerHandle Device::createCommandListLifetimeTracker(CommandQueue executionQueue)
+    {
+        (void)executionQueue;
+        m_Context.error("CommandListLifetimeTracker is not supported by the D3D11 backend.");
+        return nullptr;
+    }
+
     SamplerHandle Device::createSampler(const SamplerDesc& d)
     {
         D3D11_SAMPLER_DESC desc11;

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -899,16 +899,37 @@ namespace nvrhi::d3d12
     public:
         RefCountPtr<ID3D12CommandQueue> queue;
         RefCountPtr<ID3D12Fence> fence;
-        uint64_t lastSubmittedInstance = 0;
-        uint64_t lastCompletedInstance = 0;
-        std::atomic<uint64_t> recordingInstance = 1;
-        std::deque<std::shared_ptr<class CommandListInstance>> commandListsInFlight;
+        CommandListLifetimeTrackerHandle lifetimeTracker;
 
-        explicit Queue(const Context& context, ID3D12CommandQueue* queue);
+        std::atomic<uint64_t> lastSubmittedInstance = 0;
+        std::atomic<uint64_t> lastCompletedInstance = 0;
+        std::atomic<uint64_t> recordingInstance = 1;
+
+        explicit Queue(const Context& context, ID3D12CommandQueue* queue, CommandListLifetimeTrackerHandle&& lifetimeTracker);
         uint64_t updateLastCompletedInstance();
+        uint64_t Signal();
 
     private:
         const Context& m_Context;
+    };
+
+    class CommandListLifetimeTracker final : public RefCounter<ICommandListLifetimeTracker>
+    {
+    public:
+        CommandListLifetimeTracker(Device* device, const Context& context, DeviceResources& resources, CommandQueue executionQueue);
+
+        // ICommandListTracker implementation
+        virtual void runGarbageCollection() override;
+
+        // D3D12 specific methods
+        void push(std::shared_ptr<class CommandListInstance> commandList);
+
+    private:
+        Device* m_Device;
+        const Context& m_Context;
+        DeviceResources& m_Resources;
+        CommandQueue m_ExecutionQueue;
+        std::deque<std::shared_ptr<class CommandListInstance>> m_CommandListsInFlight;
     };
     
     class InternalCommandList
@@ -1085,6 +1106,7 @@ namespace nvrhi::d3d12
         
         IDevice* m_Device;
         Queue* m_Queue;
+        CommandListLifetimeTrackerHandle m_LifetimeTracker;
         UploadManager m_UploadManager;
         UploadManager m_DxrScratchManager;
         CommandListResourceStateTracker m_StateTracker;
@@ -1238,6 +1260,7 @@ namespace nvrhi::d3d12
         uint64_t executeCommandLists(nvrhi::ICommandList* const* pCommandLists, size_t numCommandLists, CommandQueue executionQueue = CommandQueue::Graphics) override;
         void queueWaitForCommandList(CommandQueue waitQueue, CommandQueue executionQueue, uint64_t instance) override;
         bool waitForIdle() override;
+        CommandListLifetimeTrackerHandle createCommandListLifetimeTracker(CommandQueue executionQueue) override;
         void runGarbageCollection() override;
         bool queryFeatureSupport(Feature feature, void* pInfo = nullptr, size_t infoSize = 0) override;
         FormatSupport queryFormatSupport(Format format) override;
@@ -1277,8 +1300,6 @@ namespace nvrhi::d3d12
 
         std::mutex m_Mutex;
 
-        std::vector<ID3D12CommandList*> m_CommandListsToExecute; // used locally in executeCommandLists, member to avoid re-allocations
-        
         bool m_NvapiIsInitialized = false;
         bool m_SinglePassStereoSupported = false;
         bool m_HlslExtensionsSupported = false;

--- a/src/d3d12/d3d12-commandlist.cpp
+++ b/src/d3d12/d3d12-commandlist.cpp
@@ -33,6 +33,7 @@ namespace nvrhi::d3d12
         , m_Resources(resources)
         , m_Device(device)
         , m_Queue(device->getQueue(params.queueType))
+		, m_LifetimeTracker(params.lifetimeTracker)
         , m_UploadManager(context, m_Queue, params.uploadChunkSize, 0, false)
         , m_DxrScratchManager(context, m_Queue, params.scratchChunkSize, params.scratchMaxMemory, true)
         , m_StateTracker(context.messageCallback)
@@ -364,7 +365,11 @@ namespace nvrhi::d3d12
         m_UploadManager.submitChunks(m_RecordingVersion, submittedVersion);
         m_DxrScratchManager.submitChunks(m_RecordingVersion, submittedVersion);
         m_RecordingVersion = 0;
-        
+
+        if (m_LifetimeTracker)
+            checked_cast<CommandListLifetimeTracker*>(m_LifetimeTracker.Get())->push(instance);
+        else
+			checked_cast<CommandListLifetimeTracker*>(pQueue->lifetimeTracker.Get())->push(instance);
         return instance;
     }
 

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -72,11 +72,13 @@ namespace nvrhi::d3d12
     {
     }
 
-    Queue::Queue(const Context& context, ID3D12CommandQueue* queue)
+    Queue::Queue(const Context& context, ID3D12CommandQueue* queue, CommandListLifetimeTrackerHandle&& lifetimeTracker)
         : queue(queue)
         , m_Context(context)
+		, lifetimeTracker(std::move(lifetimeTracker))
     {
         assert(queue);
+        assert(this->lifetimeTracker);
         m_Context.device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence));
     }
 
@@ -89,6 +91,65 @@ namespace nvrhi::d3d12
         return lastCompletedInstance;
     }
 
+    uint64_t Queue::Signal()
+    {
+        ++lastSubmittedInstance;
+        queue->Signal(fence, lastSubmittedInstance);
+
+        return lastSubmittedInstance;
+    }
+
+    CommandListLifetimeTracker::CommandListLifetimeTracker(Device* device, const Context& context, DeviceResources& resources, CommandQueue executionQueue)
+	    : m_Device(device)
+		, m_Context(context)
+		, m_Resources(resources)
+		, m_ExecutionQueue(executionQueue)
+    {
+    }
+
+    void CommandListLifetimeTracker::runGarbageCollection()
+    {
+        Queue* pQueue = m_Device->getQueue(m_ExecutionQueue);
+        pQueue->updateLastCompletedInstance();
+
+        // Starting from the back of the queue, i.e. oldest submitted command lists,
+        // see if those command lists have finished executing.
+        while (!m_CommandListsInFlight.empty())
+        {
+            std::shared_ptr<CommandListInstance> instance = m_CommandListsInFlight.back();
+
+            if (pQueue->lastCompletedInstance >= instance->submittedInstance)
+            {
+#ifdef NVRHI_WITH_RTXMU
+                if (!instance->rtxmuBuildIds.empty())
+                {
+                    std::lock_guard lockGuard(m_Resources.asListMutex);
+
+                    m_Resources.asBuildsCompleted.insert(m_Resources.asBuildsCompleted.end(),
+                        instance->rtxmuBuildIds.begin(), instance->rtxmuBuildIds.end());
+
+                    instance->rtxmuBuildIds.clear();
+                }
+                if (!instance->rtxmuCompactionIds.empty())
+                {
+                    m_Context.rtxMemUtil->GarbageCollection(instance->rtxmuCompactionIds);
+                    instance->rtxmuCompactionIds.clear();
+                }
+#endif
+                m_CommandListsInFlight.pop_back();
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+
+    void CommandListLifetimeTracker::push(std::shared_ptr<CommandListInstance> commandList)
+    {
+        m_CommandListsInFlight.push_front(std::move(commandList));
+    }
+
     Device::Device(const DeviceDesc& desc)
         : m_Resources(m_Context, desc)
     {
@@ -97,11 +158,11 @@ namespace nvrhi::d3d12
         m_Context.messageCallback = desc.errorCB;
 
         if (desc.pGraphicsCommandQueue)
-            m_Queues[int(CommandQueue::Graphics)] = std::make_unique<Queue>(m_Context, desc.pGraphicsCommandQueue);
+            m_Queues[int(CommandQueue::Graphics)] = std::make_unique<Queue>(m_Context, desc.pGraphicsCommandQueue, createCommandListLifetimeTracker(CommandQueue::Graphics));
         if (desc.pComputeCommandQueue)
-            m_Queues[int(CommandQueue::Compute)] = std::make_unique<Queue>(m_Context, desc.pComputeCommandQueue);
+            m_Queues[int(CommandQueue::Compute)] = std::make_unique<Queue>(m_Context, desc.pComputeCommandQueue, createCommandListLifetimeTracker(CommandQueue::Compute));
         if (desc.pCopyCommandQueue)
-            m_Queues[int(CommandQueue::Copy)] = std::make_unique<Queue>(m_Context, desc.pCopyCommandQueue);
+            m_Queues[int(CommandQueue::Copy)] = std::make_unique<Queue>(m_Context, desc.pCopyCommandQueue, createCommandListLifetimeTracker(CommandQueue::Copy));
 
         m_Resources.depthStencilViewHeap.allocateResources(D3D12_DESCRIPTOR_HEAP_TYPE_DSV, desc.depthStencilViewHeapSize, false);
         m_Resources.renderTargetViewHeap.allocateResources(D3D12_DESCRIPTOR_HEAP_TYPE_RTV, desc.renderTargetViewHeapSize, false);
@@ -181,8 +242,6 @@ namespace nvrhi::d3d12
         }
         
         m_FenceEvent = CreateEvent(nullptr, false, false, nullptr);
-
-        m_CommandListsToExecute.reserve(64);
 
 #if NVRHI_D3D12_WITH_NVAPI
         //We need to use NVAPI to set resource hints for SLI
@@ -336,7 +395,12 @@ namespace nvrhi::d3d12
         }
         return true;
     }
-    
+
+    CommandListLifetimeTrackerHandle Device::createCommandListLifetimeTracker(CommandQueue executionQueue)
+    {
+		return CommandListLifetimeTrackerHandle::Create(new CommandListLifetimeTracker(this, m_Context, m_Resources, executionQueue));
+    }
+
     Object RootSignature::getNativeObject(ObjectType objectType)
     {
         switch (objectType)
@@ -427,22 +491,20 @@ namespace nvrhi::d3d12
     
     uint64_t Device::executeCommandLists(nvrhi::ICommandList* const* pCommandLists, size_t numCommandLists, CommandQueue executionQueue)
     {
-        m_CommandListsToExecute.resize(numCommandLists);
+        std::vector<ID3D12CommandList*> commandListsToExecute(numCommandLists);
         for (size_t i = 0; i < numCommandLists; i++)
         {
-            m_CommandListsToExecute[i] = checked_cast<CommandList*>(pCommandLists[i])->getD3D12CommandList();
+            commandListsToExecute[i] = checked_cast<CommandList*>(pCommandLists[i])->getD3D12CommandList();
         }
 
         Queue* pQueue = getQueue(executionQueue);
 
-        pQueue->queue->ExecuteCommandLists(uint32_t(m_CommandListsToExecute.size()), m_CommandListsToExecute.data());
-        pQueue->lastSubmittedInstance++;
-        pQueue->queue->Signal(pQueue->fence, pQueue->lastSubmittedInstance);
+        pQueue->queue->ExecuteCommandLists(uint32_t(commandListsToExecute.size()), commandListsToExecute.data());
+        (void)pQueue->Signal();
 
         for (size_t i = 0; i < numCommandLists; i++)
         {
-            auto instance = checked_cast<CommandList*>(pCommandLists[i])->executed(pQueue);
-            pQueue->commandListsInFlight.push_front(instance);
+            (void)checked_cast<CommandList*>(pCommandLists[i])->executed(pQueue);
         }
 
         HRESULT hr = m_Context.device->GetDeviceRemovedReason();
@@ -564,39 +626,7 @@ namespace nvrhi::d3d12
             if (!pQueue)
                 continue;
 
-            pQueue->updateLastCompletedInstance();
-
-            // Starting from the back of the queue, i.e. oldest submitted command lists,
-            // see if those command lists have finished executing.
-            while (!pQueue->commandListsInFlight.empty())
-            {
-                std::shared_ptr<CommandListInstance> instance = pQueue->commandListsInFlight.back();
-                
-                if (pQueue->lastCompletedInstance >= instance->submittedInstance)
-                {
-#ifdef NVRHI_WITH_RTXMU
-                    if (!instance->rtxmuBuildIds.empty())
-                    {
-                        std::lock_guard lockGuard(m_Resources.asListMutex);
-
-                        m_Resources.asBuildsCompleted.insert(m_Resources.asBuildsCompleted.end(),
-                            instance->rtxmuBuildIds.begin(), instance->rtxmuBuildIds.end());
-
-                        instance->rtxmuBuildIds.clear();
-                    }
-                    if (!instance->rtxmuCompactionIds.empty())
-                    {
-                        m_Context.rtxMemUtil->GarbageCollection(instance->rtxmuCompactionIds);
-                        instance->rtxmuCompactionIds.clear();
-                    }
-#endif
-                    pQueue->commandListsInFlight.pop_back();
-                }
-                else
-                {
-                    break;
-                }
-            }
+            pQueue->lifetimeTracker->runGarbageCollection();
         }
     }
 

--- a/src/validation/validation-backend.h
+++ b/src/validation/validation-backend.h
@@ -387,6 +387,7 @@ namespace nvrhi::validation
         uint64_t executeCommandLists(ICommandList* const* pCommandLists, size_t numCommandLists, CommandQueue executionQueue = CommandQueue::Graphics) override;
         void queueWaitForCommandList(CommandQueue waitQueue, CommandQueue executionQueue, uint64_t instance) override;
         bool waitForIdle() override;
+        CommandListLifetimeTrackerHandle createCommandListLifetimeTracker(CommandQueue executionQueue) override;
         void runGarbageCollection() override;
         bool queryFeatureSupport(Feature feature, void* pInfo = nullptr, size_t infoSize = 0) override;
         FormatSupport queryFormatSupport(Format format) override;

--- a/src/validation/validation-device.cpp
+++ b/src/validation/validation-device.cpp
@@ -2285,6 +2285,11 @@ namespace nvrhi::validation
         return m_Device->waitForIdle();
     }
 
+    CommandListLifetimeTrackerHandle DeviceWrapper::createCommandListLifetimeTracker(CommandQueue executionQueue)
+    {
+        return m_Device->createCommandListLifetimeTracker(executionQueue);
+    }
+
     void DeviceWrapper::runGarbageCollection()
     {
         m_Device->runGarbageCollection();

--- a/src/vulkan/vulkan-backend.h
+++ b/src/vulkan/vulkan-backend.h
@@ -1153,6 +1153,7 @@ namespace nvrhi::vulkan
         uint64_t executeCommandLists(ICommandList* const* pCommandLists, size_t numCommandLists, CommandQueue executionQueue = CommandQueue::Graphics) override;
         void queueWaitForCommandList(CommandQueue waitQueue, CommandQueue executionQueue, uint64_t instance) override;
         bool waitForIdle() override;
+        CommandListLifetimeTrackerHandle createCommandListLifetimeTracker(CommandQueue executionQueue) override;
         void runGarbageCollection() override;
         bool queryFeatureSupport(Feature feature, void* pInfo = nullptr, size_t infoSize = 0) override;
         FormatSupport queryFormatSupport(Format format) override;

--- a/src/vulkan/vulkan-device.cpp
+++ b/src/vulkan/vulkan-device.cpp
@@ -321,6 +321,13 @@ namespace nvrhi::vulkan
         return true;
     }
 
+    CommandListLifetimeTrackerHandle Device::createCommandListLifetimeTracker(CommandQueue executionQueue)
+    {
+		(void)executionQueue;
+        m_Context.error("CommandListLifetimeTracker is not supported by the Vulkan backend.");
+        return nullptr;
+    }
+
     void Device::runGarbageCollection()
     {
         for (auto& m_Queue : m_Queues)


### PR DESCRIPTION
This is an implementation of the solution described in #113 

This introduces zero breaking API changes for existing code and identical behaviour for existing applications. All new behaviour to enable thread-safe work submission is entirely opt-in. A `ICommandListLifetimeTracker` is specified when creating a command list. Work is submitted as before. The details of lifetime tracking is handled by the backend; applications are required only to regularly call `runGarbageCollection` on the lifetime tracker (as is also required with the device). Command lists that do not specify a lifetime tracker will have their lifetimes managed by the Device, as before.

I have only implemented this interface in D3D12 - I am not familiar with Vulkan to implement it myself currently but I believe this interface should be achievable to implement. This interface will not be implementable in D3D11 - but NVRHI does not allow for the creation of multiple command lists in D3D11 anyway, so there is no use for it there regardless.

I have implemented an async compute example in [my fork of Donut-Samples](https://github.com/jambuttenshaw/Donut-Samples) to demonstrate this interface in action.