### PR TITLE
fix d3d12 mutable sampler descriptor table

### DIFF
--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -663,6 +663,7 @@ namespace nvrhi::d3d12
     public:
         uint32_t capacity = 0;
         DescriptorIndex firstDescriptor = 0;
+        BindingLayoutHandle layout;
 
         DescriptorTable(DeviceResources& resources)
             : m_Resources(resources)
@@ -671,7 +672,7 @@ namespace nvrhi::d3d12
         ~DescriptorTable() override;
 
         const BindingSetDesc* getDesc() const override { return nullptr; }
-        IBindingLayout* getLayout() const override { return nullptr; }
+        IBindingLayout* getLayout() const override { return layout; }
         uint32_t getCapacity() const override { return capacity; }
         uint32_t getFirstDescriptorIndexInHeap() const override { return firstDescriptor; }
 


### PR DESCRIPTION
- add support to write a sampler descriptor to a bindless descriptor table Device::writeDescriptorTable
- by querying the input IBindingLayout's BindlessLayoutDesc's layoutType (LayoutType::MutableSampler or not), we can determine if its a sampler descriptor table
- also add support for 'resizeDescriptorTable' to copy the appropriate StaticDescriptorHeap descriptors (LayoutType::MutableSampler or not)
- same for DescriptorTable destructor. release appropriate heap's descriptors