### PR TITLE
Added abstract method copyRaytracingAccelerationStructure to ICommand…

### DIFF
--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -3415,6 +3415,14 @@ namespace nvrhi
         // this function has no effect.
         virtual void compactBottomLevelAccelStructs() = 0;
 
+        // Copies a ray tracing acceleration structure to another memory location.
+        // This function clones the acceleration structure, creating a copy that can be used independently.
+        // - DX11: Not supported.
+        // - DX12: Maps to ID3D12GraphicsCommandList4::CopyRaytracingAccelerationStructure with 
+        //   D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_CLONE.
+        // - Vulkan: Maps to vkCmdCopyAccelerationStructureKHR or vkCmdCopyAccelerationStructureToMemoryKHR.
+        virtual void copyRaytracingAccelerationStructure(rt::IAccelStruct* destination, rt::IAccelStruct* source) = 0;
+
         // Builds or updates a top-level ray tracing acceleration structure (TLAS).
         // A temporary memory region for the build is suballocated using the scratch buffer manager attached to the
         // command list. The size of this memory region is determined automatically inside this function.

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -338,6 +338,7 @@ namespace nvrhi::d3d11
         void buildOpacityMicromap(rt::IOpacityMicromap* omm, const rt::OpacityMicromapDesc& desc) override;
         void buildBottomLevelAccelStruct(rt::IAccelStruct* as, const rt::GeometryDesc* pGeometries, size_t numGeometries, rt::AccelStructBuildFlags buildFlags) override;
         void compactBottomLevelAccelStructs() override;
+        void copyRaytracingAccelerationStructure(rt::IAccelStruct* destination, rt::IAccelStruct* source) override;
         void buildTopLevelAccelStruct(rt::IAccelStruct* as, const rt::InstanceDesc* pInstances, size_t numInstances, rt::AccelStructBuildFlags buildFlags) override;
         void buildTopLevelAccelStructFromBuffer(rt::IAccelStruct* as, nvrhi::IBuffer* instanceBuffer, uint64_t instanceBufferOffset, size_t numInstances,
             rt::AccelStructBuildFlags buildFlags = rt::AccelStructBuildFlags::None) override;

--- a/src/d3d11/d3d11-commandlist.cpp
+++ b/src/d3d11/d3d11-commandlist.cpp
@@ -213,6 +213,11 @@ namespace nvrhi::d3d11
         utils::NotSupported();
     }
 
+    void CommandList::copyRaytracingAccelerationStructure(rt::IAccelStruct*, rt::IAccelStruct*)
+    {
+        utils::NotSupported();
+    }
+
     void CommandList::buildTopLevelAccelStruct(rt::IAccelStruct*, const rt::InstanceDesc*, size_t, rt::AccelStructBuildFlags)
     {
         utils::NotSupported();

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -1009,6 +1009,7 @@ namespace nvrhi::d3d12
         void buildOpacityMicromap(rt::IOpacityMicromap* omm, const rt::OpacityMicromapDesc& desc) override;
         void buildBottomLevelAccelStruct(rt::IAccelStruct* as, const rt::GeometryDesc* pGeometries, size_t numGeometries, rt::AccelStructBuildFlags buildFlags) override;
         void compactBottomLevelAccelStructs() override;
+        void copyRaytracingAccelerationStructure(rt::IAccelStruct* destination, rt::IAccelStruct* source) override;
         void buildTopLevelAccelStruct(rt::IAccelStruct* as, const rt::InstanceDesc* pInstances, size_t numInstances, rt::AccelStructBuildFlags buildFlags) override;
         void buildTopLevelAccelStructFromBuffer(rt::IAccelStruct* as, nvrhi::IBuffer* instanceBuffer, uint64_t instanceBufferOffset, size_t numInstances,
             rt::AccelStructBuildFlags buildFlags = rt::AccelStructBuildFlags::None) override;

--- a/src/d3d12/d3d12-raytracing.cpp
+++ b/src/d3d12/d3d12-raytracing.cpp
@@ -2158,6 +2158,20 @@ namespace nvrhi::d3d12
 #endif
     }
 
+    void CommandList::copyRaytracingAccelerationStructure(rt::IAccelStruct* destination, rt::IAccelStruct* source)
+    {
+        AccelStruct* dstAS = checked_cast<AccelStruct*>(destination);
+        AccelStruct* srcAS = checked_cast<AccelStruct*>(source);
+
+        if (dstAS && srcAS && dstAS->dataBuffer && srcAS->dataBuffer)
+        {
+            m_ActiveCommandList->commandList4->CopyRaytracingAccelerationStructure(
+                dstAS->dataBuffer->gpuVA,
+                srcAS->dataBuffer->gpuVA,
+                D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_CLONE);
+        }
+    }
+
     void CommandList::buildTopLevelAccelStructInternal(AccelStruct* as, D3D12_GPU_VIRTUAL_ADDRESS instanceData, size_t numInstances, rt::AccelStructBuildFlags buildFlags)
     {
         // Remove the internal flag

--- a/src/d3d12/d3d12-raytracing.cpp
+++ b/src/d3d12/d3d12-raytracing.cpp
@@ -2165,6 +2165,14 @@ namespace nvrhi::d3d12
 
         if (dstAS && srcAS && dstAS->dataBuffer && srcAS->dataBuffer)
         {
+            if (m_EnableAutomaticBarriers)
+            {
+                requireBufferState(srcAS->dataBuffer, ResourceStates::AccelStructBuildBlas);
+                requireBufferState(dstAS->dataBuffer, ResourceStates::AccelStructWrite);
+                m_BindingStatesDirty = true;
+            }
+            commitBarriers();
+
             m_ActiveCommandList->commandList4->CopyRaytracingAccelerationStructure(
                 dstAS->dataBuffer->gpuVA,
                 srcAS->dataBuffer->gpuVA,

--- a/src/validation/validation-backend.h
+++ b/src/validation/validation-backend.h
@@ -238,6 +238,7 @@ namespace nvrhi::validation
         void buildOpacityMicromap(rt::IOpacityMicromap* omm, const rt::OpacityMicromapDesc& desc) override;
         void buildBottomLevelAccelStruct(rt::IAccelStruct* as, const rt::GeometryDesc* pGeometries, size_t numGeometries, rt::AccelStructBuildFlags buildFlags) override;
         void compactBottomLevelAccelStructs() override;
+        void copyRaytracingAccelerationStructure(rt::IAccelStruct* destination, rt::IAccelStruct* source) override;
         void buildTopLevelAccelStruct(rt::IAccelStruct* as, const rt::InstanceDesc* pInstances, size_t numInstances, rt::AccelStructBuildFlags buildFlags) override;
         void buildTopLevelAccelStructFromBuffer(rt::IAccelStruct* as, nvrhi::IBuffer* instanceBuffer, uint64_t instanceBufferOffset, size_t numInstances,
             rt::AccelStructBuildFlags buildFlags = rt::AccelStructBuildFlags::None) override;

--- a/src/validation/validation-commandlist.cpp
+++ b/src/validation/validation-commandlist.cpp
@@ -1177,6 +1177,32 @@ namespace nvrhi::validation
         m_CommandList->compactBottomLevelAccelStructs();
     }
 
+    void CommandListWrapper::copyRaytracingAccelerationStructure(rt::IAccelStruct* destination, rt::IAccelStruct* source)
+    {
+        if (!requireOpenState())
+            return;
+
+        if (!requireType(CommandQueue::Compute, "copyRaytracingAccelerationStructure"))
+            return;
+
+        rt::IAccelStruct* underlyingDst = destination;
+        rt::IAccelStruct* underlyingSrc = source;
+
+        AccelStructWrapper* dstWrapper = dynamic_cast<AccelStructWrapper*>(destination);
+        if (dstWrapper)
+        {
+            underlyingDst = dstWrapper->getUnderlyingObject();
+        }
+
+        AccelStructWrapper* srcWrapper = dynamic_cast<AccelStructWrapper*>(source);
+        if (srcWrapper)
+        {
+            underlyingSrc = srcWrapper->getUnderlyingObject();
+        }
+
+        m_CommandList->copyRaytracingAccelerationStructure(underlyingDst, underlyingSrc);
+    }
+
     void CommandListWrapper::buildOpacityMicromap(rt::IOpacityMicromap* omm, const rt::OpacityMicromapDesc& desc) 
     {
         if (!requireOpenState())

--- a/src/vulkan/vulkan-backend.h
+++ b/src/vulkan/vulkan-backend.h
@@ -1248,6 +1248,7 @@ namespace nvrhi::vulkan
         void buildOpacityMicromap(rt::IOpacityMicromap* omm, const rt::OpacityMicromapDesc& desc) override;
         void buildBottomLevelAccelStruct(rt::IAccelStruct* as, const rt::GeometryDesc* pGeometries, size_t numGeometries, rt::AccelStructBuildFlags buildFlags) override;
         void compactBottomLevelAccelStructs() override;
+        void copyRaytracingAccelerationStructure(rt::IAccelStruct* destination, rt::IAccelStruct* source) override;
         void buildTopLevelAccelStruct(rt::IAccelStruct* as, const rt::InstanceDesc* pInstances, size_t numInstances, rt::AccelStructBuildFlags buildFlags) override;
         void buildTopLevelAccelStructFromBuffer(rt::IAccelStruct* as, nvrhi::IBuffer* instanceBuffer, uint64_t instanceBufferOffset, size_t numInstances,
             rt::AccelStructBuildFlags buildFlags = rt::AccelStructBuildFlags::None) override;

--- a/src/vulkan/vulkan-raytracing.cpp
+++ b/src/vulkan/vulkan-raytracing.cpp
@@ -864,6 +864,22 @@ namespace nvrhi::vulkan
 #endif
     }
 
+    void CommandList::copyRaytracingAccelerationStructure(rt::IAccelStruct* destination, rt::IAccelStruct* source)
+    {
+        AccelStruct* dstAS = checked_cast<AccelStruct*>(destination);
+        AccelStruct* srcAS = checked_cast<AccelStruct*>(source);
+
+        if (dstAS && srcAS && dstAS->accelStruct && srcAS->accelStruct)
+        {
+            vk::CopyAccelerationStructureInfoKHR copyInfo;
+            copyInfo.src = srcAS->accelStruct;
+            copyInfo.dst = dstAS->accelStruct;
+            copyInfo.mode = vk::CopyAccelerationStructureModeKHR::eClone;
+
+            m_CurrentCmdBuf->cmdBuf.copyAccelerationStructureKHR(copyInfo);
+        }
+    }
+
     void CommandList::buildTopLevelAccelStructInternal(AccelStruct* as, VkDeviceAddress instanceData, size_t numInstances, rt::AccelStructBuildFlags buildFlags, uint64_t currentVersion)
     {
         // Remove the internal flag

--- a/src/vulkan/vulkan-raytracing.cpp
+++ b/src/vulkan/vulkan-raytracing.cpp
@@ -871,6 +871,14 @@ namespace nvrhi::vulkan
 
         if (dstAS && srcAS && dstAS->accelStruct && srcAS->accelStruct)
         {
+            if (m_EnableAutomaticBarriers)
+            {
+                requireBufferState(srcAS->dataBuffer, ResourceStates::AccelStructBuildBlas);
+                requireBufferState(dstAS->dataBuffer, ResourceStates::AccelStructWrite);
+                m_BindingStatesDirty = true;
+            }
+            commitBarriers();
+
             vk::CopyAccelerationStructureInfoKHR copyInfo;
             copyInfo.src = srcAS->accelStruct;
             copyInfo.dst = dstAS->accelStruct;


### PR DESCRIPTION
…List

d3d12:
Uses ID3D12GraphicsCommandList4::CopyRaytracingAccelerationStructure

vulkan:
Uses vkCmdCopyAccelerationStructureKHR