### PR TITLE
Bugfix: VB updates depending on non-null IB.

### DIFF
--- a/src/d3d12/d3d12-graphics.cpp
+++ b/src/d3d12/d3d12-graphics.cpp
@@ -422,7 +422,7 @@ namespace nvrhi::d3d12
             m_ActiveCommandList->commandList->IASetVertexBuffers(0, maxVbIndex + 1, VBVs);
         }
 
-        if (m_EnableAutomaticBarriers && state.indexBuffer.buffer && (m_BindingStatesDirty || updateVertexBuffers))
+        if (m_EnableAutomaticBarriers && !state.vertexBuffers.empty() && (m_BindingStatesDirty || updateVertexBuffers))
         {
             for (const VertexBufferBinding& binding : state.vertexBuffers)
             {


### PR DESCRIPTION
Seems like a bug was recently introduced where draw calls without an IB prevents VBs from being updated.

This results in the error "Resource state (0x400: D3D12_RESOURCE_STATE_COPY_DEST) of resource XXX (subresource: 0) is invalid for use as a vertex buffer.  Expected State Bits (all): 0x1: D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER, Actual State: 0x400: D3D12_RESOURCE_STATE_COPY_DEST, Missing State: 0x1: D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER. [ EXECUTION ERROR #538: INVALID_SUBRESOURCE_STATE]" when copying to a VB prior to drawing.

Copy-paste mistake perhaps?