### PR TITLE
improvement: Make the offset in the BLAS geometry triangles respect the stride of their data types

### DIFF
--- a/src/d3d12/d3d12-raytracing.cpp
+++ b/src/d3d12/d3d12-raytracing.cpp
@@ -548,12 +548,12 @@ namespace nvrhi::d3d12
         const auto& triangles = geometryDesc.geometryData.triangles;
 
         if (triangles.indexBuffer)
-            outDxrTriangles.IndexBuffer = checked_cast<Buffer*>(triangles.indexBuffer)->gpuVA + triangles.indexOffset;
+            outDxrTriangles.IndexBuffer = checked_cast<Buffer*>(triangles.indexBuffer)->gpuVA + triangles.indexOffset * getFormatInfo(triangles.indexFormat).bytesPerBlock;
         else
             outDxrTriangles.IndexBuffer = 0;
 
         if (triangles.vertexBuffer)
-            outDxrTriangles.VertexBuffer.StartAddress = checked_cast<Buffer*>(triangles.vertexBuffer)->gpuVA + triangles.vertexOffset;
+            outDxrTriangles.VertexBuffer.StartAddress = checked_cast<Buffer*>(triangles.vertexBuffer)->gpuVA + triangles.vertexOffset * triangles.vertexStride;
         else
             outDxrTriangles.VertexBuffer.StartAddress = 0;
 

--- a/src/vulkan/vulkan-raytracing.cpp
+++ b/src/vulkan/vulkan-raytracing.cpp
@@ -110,10 +110,10 @@ namespace nvrhi::vulkan
             vk::AccelerationStructureGeometryTrianglesDataKHR dstt;
 
             dstt.setIndexType(convertIndexFormatToType(srct.indexFormat, true));
-            dstt.setIndexData(getBufferAddress(srct.indexBuffer, srct.indexOffset));
+            dstt.setIndexData(getBufferAddress(srct.indexBuffer, srct.indexOffset * getFormatInfo(srct.indexFormat).bytesPerBlock));
 
             dstt.setVertexFormat(vk::Format(convertFormat(srct.vertexFormat)));
-            dstt.setVertexData(getBufferAddress(srct.vertexBuffer, srct.vertexOffset));
+            dstt.setVertexData(getBufferAddress(srct.vertexBuffer, srct.vertexOffset * srct.vertexStride));
             dstt.setVertexStride(srct.vertexStride);
             dstt.setMaxVertex(std::max(srct.vertexCount, 1u) - 1u);
 


### PR DESCRIPTION
When trying to build BLAS I expected that "indexOffset" and "vertexOffset" would respect the given stride from indexFormat and vertexStride but the implementation defines these offsets as a byte offsets. If this is intended could it be more clear (e.g. by calling them vertexByteOffset or adding a comment in the data structure)

NVRHI has been great for learning more about modern graphics. Thanks for all the wonderful work you guys are doing ❤️