### PR TITLE
Vulkan: gate the LSS pipeline-create flag 

### DIFF
--- a/src/vulkan/vulkan-raytracing.cpp
+++ b/src/vulkan/vulkan-raytracing.cpp
@@ -1626,15 +1626,22 @@ namespace nvrhi::vulkan
             .setAllowClusterAccelerationStructure(true);
 
         auto pipelineFlags2 = vk::PipelineCreateFlags2CreateInfoKHR();
-        pipelineFlags2.setFlags(vk::PipelineCreateFlagBits2::eRayTracingAllowSpheresAndLinearSweptSpheresNV);
+        if (m_Context.extensions.NV_ray_tracing_linear_swept_spheres)
+        {
+            pipelineFlags2.setFlags(vk::PipelineCreateFlagBits2::eRayTracingAllowSpheresAndLinearSweptSpheresNV);
+        }
 
         auto pipelineInfo = vk::RayTracingPipelineCreateInfoKHR()
             .setStages(shaderStages)
             .setGroups(shaderGroups)
             .setLayout(pso->pipelineLayout)
             .setMaxPipelineRayRecursionDepth(desc.maxRecursionDepth)
-            .setPLibraryInfo(&libraryInfo)
-            .setPNext(&pipelineFlags2);
+            .setPLibraryInfo(&libraryInfo);
+
+        if (m_Context.extensions.NV_ray_tracing_linear_swept_spheres)
+        {
+            pipelineInfo.setPNext(&pipelineFlags2);
+        }
 
         if (m_Context.extensions.NV_cluster_acceleration_structure)
         {


### PR DESCRIPTION
createRayTracingPipeline currently chains a
VkPipelineCreateFlags2CreateInfoKHR with
VK_PIPELINE_CREATE_2_RAY_TRACING_ALLOW_SPHERES_AND_LINEAR_SWEPT_SPHERES_BIT_NV into every RT pipeline create unconditionally. The Flags2 struct itself requires VK_KHR_maintenance5 (or Vulkan 1.4); the flag bit requires VK_NV_ray_tracing_linear_swept_spheres. On hardware / drivers that don't expose VK_NV_ray_tracing_linear_swept_spheres (e.g. several consumer Ada-class GPUs on current proprietary drivers) vkCreateRayTracingPipelinesKHR fails outright on every RT pipeline.

Mirror the NV_cluster_acceleration_structure pattern just below: only set the flag bit and chain pipelineFlags2 into pNext when the LSS extension is actually enabled on the device. Apps that *do* enable VK_NV_ray_tracing_linear_swept_spheres see the existing behaviour unchanged.

## Tested on

- RTX 4070 Laptop, driver 596.36, Vulkan SDK 1.4.329 — RT pipeline create
  succeeds with the patch (previously failed).
- No regression for apps that enable `VK_NV_ray_tracing_linear_swept_spheres`
  (the gated `if` evaluates true, code path identical).