### PR TITLE
Adding CommandListLifetimeTracker for DX12 and Vulkan

### DIFF
--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -3087,6 +3087,7 @@ namespace nvrhi
     };
     
     class IDevice;
+    class ICommandListLifetimeTracker;
 
     struct CommandListParameters
     {
@@ -3107,13 +3108,41 @@ namespace nvrhi
         // COPY and COMPUTE queues have limited subsets of methods available.
         CommandQueue queueType = CommandQueue::Graphics;
 
+        // Optional external lifetime tracker to use for this command list.
+        // If left nullptr, lifetime will be tracked by the device.
+        ICommandListLifetimeTracker* lifetimeTracker = nullptr;
+
         CommandListParameters& setEnableImmediateExecution(bool value) { enableImmediateExecution = value; return *this; }
         CommandListParameters& setUploadChunkSize(size_t value) { uploadChunkSize = value; return *this; }
         CommandListParameters& setScratchChunkSize(size_t value) { scratchChunkSize = value; return *this; }
         CommandListParameters& setScratchMaxMemory(size_t value) { scratchMaxMemory = value; return *this; }
         CommandListParameters& setQueueType(CommandQueue value) { queueType = value; return *this; }
+        CommandListParameters& setLifetimeTracker(ICommandListLifetimeTracker* value) { lifetimeTracker = value; return *this; }
     };
-    
+
+    //////////////////////////////////////////////////////////////////////////
+    // ICommandListLifetimeTracker
+    //////////////////////////////////////////////////////////////////////////
+
+    // Manages the lifetime of command list objects in a way that is scalable for multithreading.
+    // Each thread that submits work to the GPU (calls IDevice::executeCommandList[s]) should own its own command list tracker
+    // for each queue it submits work to.
+    // - DX11: Multithreaded work submission is not supported.
+    // - DX12: A lifetime tracker can be optionally specified when creating a command list. After submitting a command list,
+	//   internal command lists and their referenced resources will be held by the lifetime tracker until work has finished
+	//   execution on the GPU. Execute runGarbageCollection frequently to poll the GPU and release resources when possible.
+    //   If no lifetime tracker is specified, the Device will add the command list to its own internal lifetime trackers.
+    // - Vulkan: Not yet implemented.
+    class ICommandListLifetimeTracker : public IResource
+    {
+    public:
+        // Releases any command lists that have finished executing on the GPU.
+        // This should be called frequently, e.g. once per frame, once per simulation step, etc.
+        virtual void runGarbageCollection() = 0;
+    };
+
+    typedef RefCountPtr<ICommandListLifetimeTracker> CommandListLifetimeTrackerHandle;
+
     //////////////////////////////////////////////////////////////////////////
     // ICommandList
     //////////////////////////////////////////////////////////////////////////
@@ -3684,6 +3713,8 @@ namespace nvrhi
         virtual void queueWaitForCommandList(CommandQueue waitQueue, CommandQueue executionQueue, uint64_t instance) = 0;
         // returns true if the wait completes successfully, false if detecting a problem (e.g. device removal)
         virtual bool waitForIdle() = 0;
+
+        virtual CommandListLifetimeTrackerHandle createCommandListLifetimeTracker(CommandQueue executionQueue) = 0;
 
         // Releases the resources that were referenced in the command lists that have finished executing.
         // IMPORTANT: Call this method at least once per frame.

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -521,6 +521,7 @@ namespace nvrhi::d3d11
         uint64_t executeCommandLists(ICommandList* const* pCommandLists, size_t numCommandLists, CommandQueue executionQueue = CommandQueue::Graphics) override { (void)pCommandLists; (void)numCommandLists; (void)executionQueue; return 0; }
         void queueWaitForCommandList(CommandQueue waitQueue, CommandQueue executionQueue, uint64_t instance) override { (void)waitQueue; (void)executionQueue; (void)instance; }
         bool waitForIdle() override;
+        CommandListLifetimeTrackerHandle createCommandListLifetimeTracker(CommandQueue executionQueue) override;
         void runGarbageCollection() override { }
         bool queryFeatureSupport(Feature feature, void* pInfo = nullptr, size_t infoSize = 0) override;
         FormatSupport queryFormatSupport(Format format) override;

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -362,6 +362,13 @@ namespace nvrhi::d3d11
         return true;
     }
 
+    CommandListLifetimeTrackerHandle Device::createCommandListLifetimeTracker(CommandQueue executionQueue)
+    {
+        (void)executionQueue;
+        m_Context.error("CommandListLifetimeTracker is not supported by the D3D11 backend.");
+        return nullptr;
+    }
+
     SamplerHandle Device::createSampler(const SamplerDesc& d)
     {
         D3D11_SAMPLER_DESC desc11;

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -899,16 +899,37 @@ namespace nvrhi::d3d12
     public:
         RefCountPtr<ID3D12CommandQueue> queue;
         RefCountPtr<ID3D12Fence> fence;
-        uint64_t lastSubmittedInstance = 0;
-        uint64_t lastCompletedInstance = 0;
-        std::atomic<uint64_t> recordingInstance = 1;
-        std::deque<std::shared_ptr<class CommandListInstance>> commandListsInFlight;
+        CommandListLifetimeTrackerHandle lifetimeTracker;
 
-        explicit Queue(const Context& context, ID3D12CommandQueue* queue);
+        std::atomic<uint64_t> lastSubmittedInstance = 0;
+        std::atomic<uint64_t> lastCompletedInstance = 0;
+        std::atomic<uint64_t> recordingInstance = 1;
+
+        explicit Queue(const Context& context, ID3D12CommandQueue* queue, CommandListLifetimeTrackerHandle&& lifetimeTracker);
         uint64_t updateLastCompletedInstance();
+        uint64_t Signal();
 
     private:
         const Context& m_Context;
+    };
+
+    class CommandListLifetimeTracker final : public RefCounter<ICommandListLifetimeTracker>
+    {
+    public:
+        CommandListLifetimeTracker(Device* device, const Context& context, DeviceResources& resources, CommandQueue executionQueue);
+
+        // ICommandListTracker implementation
+        virtual void runGarbageCollection() override;
+
+        // D3D12 specific methods
+        void push(std::shared_ptr<class CommandListInstance> commandList);
+
+    private:
+        Device* m_Device;
+        const Context& m_Context;
+        DeviceResources& m_Resources;
+        CommandQueue m_ExecutionQueue;
+        std::deque<std::shared_ptr<class CommandListInstance>> m_CommandListsInFlight;
     };
     
     class InternalCommandList
@@ -1085,6 +1106,7 @@ namespace nvrhi::d3d12
         
         IDevice* m_Device;
         Queue* m_Queue;
+        CommandListLifetimeTrackerHandle m_LifetimeTracker;
         UploadManager m_UploadManager;
         UploadManager m_DxrScratchManager;
         CommandListResourceStateTracker m_StateTracker;
@@ -1238,6 +1260,7 @@ namespace nvrhi::d3d12
         uint64_t executeCommandLists(nvrhi::ICommandList* const* pCommandLists, size_t numCommandLists, CommandQueue executionQueue = CommandQueue::Graphics) override;
         void queueWaitForCommandList(CommandQueue waitQueue, CommandQueue executionQueue, uint64_t instance) override;
         bool waitForIdle() override;
+        CommandListLifetimeTrackerHandle createCommandListLifetimeTracker(CommandQueue executionQueue) override;
         void runGarbageCollection() override;
         bool queryFeatureSupport(Feature feature, void* pInfo = nullptr, size_t infoSize = 0) override;
         FormatSupport queryFormatSupport(Format format) override;
@@ -1277,8 +1300,6 @@ namespace nvrhi::d3d12
 
         std::mutex m_Mutex;
 
-        std::vector<ID3D12CommandList*> m_CommandListsToExecute; // used locally in executeCommandLists, member to avoid re-allocations
-        
         bool m_NvapiIsInitialized = false;
         bool m_SinglePassStereoSupported = false;
         bool m_HlslExtensionsSupported = false;

--- a/src/d3d12/d3d12-commandlist.cpp
+++ b/src/d3d12/d3d12-commandlist.cpp
@@ -33,6 +33,7 @@ namespace nvrhi::d3d12
         , m_Resources(resources)
         , m_Device(device)
         , m_Queue(device->getQueue(params.queueType))
+		, m_LifetimeTracker(params.lifetimeTracker)
         , m_UploadManager(context, m_Queue, params.uploadChunkSize, 0, false)
         , m_DxrScratchManager(context, m_Queue, params.scratchChunkSize, params.scratchMaxMemory, true)
         , m_StateTracker(context.messageCallback)
@@ -364,7 +365,11 @@ namespace nvrhi::d3d12
         m_UploadManager.submitChunks(m_RecordingVersion, submittedVersion);
         m_DxrScratchManager.submitChunks(m_RecordingVersion, submittedVersion);
         m_RecordingVersion = 0;
-        
+
+        if (m_LifetimeTracker)
+            checked_cast<CommandListLifetimeTracker*>(m_LifetimeTracker.Get())->push(instance);
+        else
+			checked_cast<CommandListLifetimeTracker*>(pQueue->lifetimeTracker.Get())->push(instance);
         return instance;
     }
 

--- a/src/d3d12/d3d12-constants.cpp
+++ b/src/d3d12/d3d12-constants.cpp
@@ -251,7 +251,7 @@ namespace nvrhi::d3d12
         if ((stateBits & ResourceStates::VertexBuffer) != 0) result |= D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
         if ((stateBits & ResourceStates::IndexBuffer) != 0) result |= D3D12_RESOURCE_STATE_INDEX_BUFFER;
         if ((stateBits & ResourceStates::IndirectArgument) != 0) result |= D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT;
-        if ((stateBits & ResourceStates::ShaderResource) != 0) result |= D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+        if ((stateBits & ResourceStates::ShaderResource) != 0) result |= D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
         if ((stateBits & ResourceStates::UnorderedAccess) != 0) result |= D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
         if ((stateBits & ResourceStates::RenderTarget) != 0) result |= D3D12_RESOURCE_STATE_RENDER_TARGET;
         if ((stateBits & ResourceStates::DepthWrite) != 0) result |= D3D12_RESOURCE_STATE_DEPTH_WRITE;

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -72,11 +72,13 @@ namespace nvrhi::d3d12
     {
     }
 
-    Queue::Queue(const Context& context, ID3D12CommandQueue* queue)
+    Queue::Queue(const Context& context, ID3D12CommandQueue* queue, CommandListLifetimeTrackerHandle&& lifetimeTracker)
         : queue(queue)
         , m_Context(context)
+		, lifetimeTracker(std::move(lifetimeTracker))
     {
         assert(queue);
+        assert(this->lifetimeTracker);
         m_Context.device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence));
     }
 
@@ -89,6 +91,65 @@ namespace nvrhi::d3d12
         return lastCompletedInstance;
     }
 
+    uint64_t Queue::Signal()
+    {
+        ++lastSubmittedInstance;
+        queue->Signal(fence, lastSubmittedInstance);
+
+        return lastSubmittedInstance;
+    }
+
+    CommandListLifetimeTracker::CommandListLifetimeTracker(Device* device, const Context& context, DeviceResources& resources, CommandQueue executionQueue)
+	    : m_Device(device)
+		, m_Context(context)
+		, m_Resources(resources)
+		, m_ExecutionQueue(executionQueue)
+    {
+    }
+
+    void CommandListLifetimeTracker::runGarbageCollection()
+    {
+        Queue* pQueue = m_Device->getQueue(m_ExecutionQueue);
+        pQueue->updateLastCompletedInstance();
+
+        // Starting from the back of the queue, i.e. oldest submitted command lists,
+        // see if those command lists have finished executing.
+        while (!m_CommandListsInFlight.empty())
+        {
+            std::shared_ptr<CommandListInstance> instance = m_CommandListsInFlight.back();
+
+            if (pQueue->lastCompletedInstance >= instance->submittedInstance)
+            {
+#ifdef NVRHI_WITH_RTXMU
+                if (!instance->rtxmuBuildIds.empty())
+                {
+                    std::lock_guard lockGuard(m_Resources.asListMutex);
+
+                    m_Resources.asBuildsCompleted.insert(m_Resources.asBuildsCompleted.end(),
+                        instance->rtxmuBuildIds.begin(), instance->rtxmuBuildIds.end());
+
+                    instance->rtxmuBuildIds.clear();
+                }
+                if (!instance->rtxmuCompactionIds.empty())
+                {
+                    m_Context.rtxMemUtil->GarbageCollection(instance->rtxmuCompactionIds);
+                    instance->rtxmuCompactionIds.clear();
+                }
+#endif
+                m_CommandListsInFlight.pop_back();
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+
+    void CommandListLifetimeTracker::push(std::shared_ptr<CommandListInstance> commandList)
+    {
+        m_CommandListsInFlight.push_front(std::move(commandList));
+    }
+
     Device::Device(const DeviceDesc& desc)
         : m_Resources(m_Context, desc)
     {
@@ -97,11 +158,11 @@ namespace nvrhi::d3d12
         m_Context.messageCallback = desc.errorCB;
 
         if (desc.pGraphicsCommandQueue)
-            m_Queues[int(CommandQueue::Graphics)] = std::make_unique<Queue>(m_Context, desc.pGraphicsCommandQueue);
+            m_Queues[int(CommandQueue::Graphics)] = std::make_unique<Queue>(m_Context, desc.pGraphicsCommandQueue, createCommandListLifetimeTracker(CommandQueue::Graphics));
         if (desc.pComputeCommandQueue)
-            m_Queues[int(CommandQueue::Compute)] = std::make_unique<Queue>(m_Context, desc.pComputeCommandQueue);
+            m_Queues[int(CommandQueue::Compute)] = std::make_unique<Queue>(m_Context, desc.pComputeCommandQueue, createCommandListLifetimeTracker(CommandQueue::Compute));
         if (desc.pCopyCommandQueue)
-            m_Queues[int(CommandQueue::Copy)] = std::make_unique<Queue>(m_Context, desc.pCopyCommandQueue);
+            m_Queues[int(CommandQueue::Copy)] = std::make_unique<Queue>(m_Context, desc.pCopyCommandQueue, createCommandListLifetimeTracker(CommandQueue::Copy));
 
         m_Resources.depthStencilViewHeap.allocateResources(D3D12_DESCRIPTOR_HEAP_TYPE_DSV, desc.depthStencilViewHeapSize, false);
         m_Resources.renderTargetViewHeap.allocateResources(D3D12_DESCRIPTOR_HEAP_TYPE_RTV, desc.renderTargetViewHeapSize, false);
@@ -181,8 +242,6 @@ namespace nvrhi::d3d12
         }
         
         m_FenceEvent = CreateEvent(nullptr, false, false, nullptr);
-
-        m_CommandListsToExecute.reserve(64);
 
 #if NVRHI_D3D12_WITH_NVAPI
         //We need to use NVAPI to set resource hints for SLI
@@ -336,7 +395,12 @@ namespace nvrhi::d3d12
         }
         return true;
     }
-    
+
+    CommandListLifetimeTrackerHandle Device::createCommandListLifetimeTracker(CommandQueue executionQueue)
+    {
+		return CommandListLifetimeTrackerHandle::Create(new CommandListLifetimeTracker(this, m_Context, m_Resources, executionQueue));
+    }
+
     Object RootSignature::getNativeObject(ObjectType objectType)
     {
         switch (objectType)
@@ -427,22 +491,20 @@ namespace nvrhi::d3d12
     
     uint64_t Device::executeCommandLists(nvrhi::ICommandList* const* pCommandLists, size_t numCommandLists, CommandQueue executionQueue)
     {
-        m_CommandListsToExecute.resize(numCommandLists);
+        std::vector<ID3D12CommandList*> commandListsToExecute(numCommandLists);
         for (size_t i = 0; i < numCommandLists; i++)
         {
-            m_CommandListsToExecute[i] = checked_cast<CommandList*>(pCommandLists[i])->getD3D12CommandList();
+            commandListsToExecute[i] = checked_cast<CommandList*>(pCommandLists[i])->getD3D12CommandList();
         }
 
         Queue* pQueue = getQueue(executionQueue);
 
-        pQueue->queue->ExecuteCommandLists(uint32_t(m_CommandListsToExecute.size()), m_CommandListsToExecute.data());
-        pQueue->lastSubmittedInstance++;
-        pQueue->queue->Signal(pQueue->fence, pQueue->lastSubmittedInstance);
+        pQueue->queue->ExecuteCommandLists(uint32_t(commandListsToExecute.size()), commandListsToExecute.data());
+        (void)pQueue->Signal();
 
         for (size_t i = 0; i < numCommandLists; i++)
         {
-            auto instance = checked_cast<CommandList*>(pCommandLists[i])->executed(pQueue);
-            pQueue->commandListsInFlight.push_front(instance);
+            (void)checked_cast<CommandList*>(pCommandLists[i])->executed(pQueue);
         }
 
         HRESULT hr = m_Context.device->GetDeviceRemovedReason();
@@ -564,39 +626,7 @@ namespace nvrhi::d3d12
             if (!pQueue)
                 continue;
 
-            pQueue->updateLastCompletedInstance();
-
-            // Starting from the back of the queue, i.e. oldest submitted command lists,
-            // see if those command lists have finished executing.
-            while (!pQueue->commandListsInFlight.empty())
-            {
-                std::shared_ptr<CommandListInstance> instance = pQueue->commandListsInFlight.back();
-                
-                if (pQueue->lastCompletedInstance >= instance->submittedInstance)
-                {
-#ifdef NVRHI_WITH_RTXMU
-                    if (!instance->rtxmuBuildIds.empty())
-                    {
-                        std::lock_guard lockGuard(m_Resources.asListMutex);
-
-                        m_Resources.asBuildsCompleted.insert(m_Resources.asBuildsCompleted.end(),
-                            instance->rtxmuBuildIds.begin(), instance->rtxmuBuildIds.end());
-
-                        instance->rtxmuBuildIds.clear();
-                    }
-                    if (!instance->rtxmuCompactionIds.empty())
-                    {
-                        m_Context.rtxMemUtil->GarbageCollection(instance->rtxmuCompactionIds);
-                        instance->rtxmuCompactionIds.clear();
-                    }
-#endif
-                    pQueue->commandListsInFlight.pop_back();
-                }
-                else
-                {
-                    break;
-                }
-            }
+            pQueue->lifetimeTracker->runGarbageCollection();
         }
     }
 

--- a/src/validation/validation-backend.h
+++ b/src/validation/validation-backend.h
@@ -387,6 +387,7 @@ namespace nvrhi::validation
         uint64_t executeCommandLists(ICommandList* const* pCommandLists, size_t numCommandLists, CommandQueue executionQueue = CommandQueue::Graphics) override;
         void queueWaitForCommandList(CommandQueue waitQueue, CommandQueue executionQueue, uint64_t instance) override;
         bool waitForIdle() override;
+        CommandListLifetimeTrackerHandle createCommandListLifetimeTracker(CommandQueue executionQueue) override;
         void runGarbageCollection() override;
         bool queryFeatureSupport(Feature feature, void* pInfo = nullptr, size_t infoSize = 0) override;
         FormatSupport queryFormatSupport(Format format) override;

--- a/src/validation/validation-device.cpp
+++ b/src/validation/validation-device.cpp
@@ -2285,6 +2285,11 @@ namespace nvrhi::validation
         return m_Device->waitForIdle();
     }
 
+    CommandListLifetimeTrackerHandle DeviceWrapper::createCommandListLifetimeTracker(CommandQueue executionQueue)
+    {
+        return m_Device->createCommandListLifetimeTracker(executionQueue);
+    }
+
     void DeviceWrapper::runGarbageCollection()
     {
         m_Device->runGarbageCollection();

--- a/src/vulkan/vulkan-backend.h
+++ b/src/vulkan/vulkan-backend.h
@@ -221,6 +221,25 @@ namespace nvrhi::vulkan
 
     typedef std::shared_ptr<TrackedCommandBuffer> TrackedCommandBufferPtr;
 
+    class Queue;
+    class CommandListLifetimeTracker final : public RefCounter<ICommandListLifetimeTracker>
+    {
+    public:
+        CommandListLifetimeTracker(const VulkanContext& context, Queue* queue);
+
+        // ICommandListTracker implementation
+        virtual void runGarbageCollection() override;
+
+        // Vulkan specific methods
+        void push(TrackedCommandBufferPtr commandBuffer);
+        Queue* getQueue() const { return m_Queue; }
+
+    private:
+        const VulkanContext& m_Context;
+        Queue* m_Queue;
+        std::list<TrackedCommandBufferPtr> m_CommandBuffersInFlight;
+    };
+
     // represents a hardware queue
     class Queue
     {
@@ -244,9 +263,7 @@ namespace nvrhi::vulkan
         void updateTextureTileMappings(ITexture* texture, const TextureTilesMapping* tileMappings, uint32_t numTileMappings);
 
         // retire any command buffers that have finished execution from the pending execution list
-        void retireCommandBuffers();
-
-        TrackedCommandBufferPtr getCommandBufferInFlight(uint64_t submissionID);
+        void runGarbageCollection();
 
         uint64_t updateLastFinishedID();
         uint64_t getLastSubmittedID() const { return m_LastSubmittedID; }
@@ -275,8 +292,11 @@ namespace nvrhi::vulkan
         uint64_t m_LastFinishedID = 0;
 
         // tracks the list of command buffers in flight on this queue
-        std::list<TrackedCommandBufferPtr> m_CommandBuffersInFlight;
         std::list<TrackedCommandBufferPtr> m_CommandBuffersPool;
+        CommandListLifetimeTracker m_LifetimeTracker;
+
+        friend class CommandListLifetimeTracker;
+        void returnCommandBuffersToPool(std::list<TrackedCommandBufferPtr> const& commandBuffers);
     };
 
     class MemoryResource

--- a/src/vulkan/vulkan-backend.h
+++ b/src/vulkan/vulkan-backend.h
@@ -1153,6 +1153,7 @@ namespace nvrhi::vulkan
         uint64_t executeCommandLists(ICommandList* const* pCommandLists, size_t numCommandLists, CommandQueue executionQueue = CommandQueue::Graphics) override;
         void queueWaitForCommandList(CommandQueue waitQueue, CommandQueue executionQueue, uint64_t instance) override;
         bool waitForIdle() override;
+        CommandListLifetimeTrackerHandle createCommandListLifetimeTracker(CommandQueue executionQueue) override;
         void runGarbageCollection() override;
         bool queryFeatureSupport(Feature feature, void* pInfo = nullptr, size_t infoSize = 0) override;
         FormatSupport queryFormatSupport(Format format) override;

--- a/src/vulkan/vulkan-device.cpp
+++ b/src/vulkan/vulkan-device.cpp
@@ -321,6 +321,13 @@ namespace nvrhi::vulkan
         return true;
     }
 
+    CommandListLifetimeTrackerHandle Device::createCommandListLifetimeTracker(CommandQueue executionQueue)
+    {
+		(void)executionQueue;
+        m_Context.error("CommandListLifetimeTracker is not supported by the Vulkan backend.");
+        return nullptr;
+    }
+
     void Device::runGarbageCollection()
     {
         for (auto& m_Queue : m_Queues)

--- a/src/vulkan/vulkan-device.cpp
+++ b/src/vulkan/vulkan-device.cpp
@@ -324,9 +324,7 @@ namespace nvrhi::vulkan
 
     CommandListLifetimeTrackerHandle Device::createCommandListLifetimeTracker(CommandQueue executionQueue)
     {
-		(void)executionQueue;
-        m_Context.error("CommandListLifetimeTracker is not supported by the Vulkan backend.");
-        return nullptr;
+		return CommandListLifetimeTrackerHandle::Create(new CommandListLifetimeTracker(m_Context, getQueue(executionQueue)));
     }
 
     void Device::runGarbageCollection()
@@ -335,7 +333,7 @@ namespace nvrhi::vulkan
         {
             if (m_Queue)
             {
-                m_Queue->retireCommandBuffers();
+                m_Queue->runGarbageCollection();
             }
         }
     }

--- a/src/vulkan/vulkan-queue.cpp
+++ b/src/vulkan/vulkan-queue.cpp
@@ -37,6 +37,7 @@ namespace nvrhi::vulkan
         , m_Queue(queue)
         , m_QueueID(queueID)
         , m_QueueFamilyIndex(queueFamilyIndex)
+        , m_LifetimeTracker(context, this)
     {
         auto semaphoreTypeInfo = vk::SemaphoreTypeCreateInfo()
             .setSemaphoreType(vk::SemaphoreType::eTimeline);
@@ -120,6 +121,13 @@ namespace nvrhi::vulkan
 
     uint64_t Queue::submit(ICommandList* const* ppCmd, size_t numCmd)
     {
+        // We want submit() to be free-threaded, but it accesses various members like m_WaitSemaphores,
+        // so use a mutex for synchronization.
+        // Note that these semaphore lists are persistent state of Queue, so vulkan::IDevice's methods
+        // queueWaitForSemaphore and queueSignalSemaphore will not work well with multi-threaded command list
+        // submission to the same queue.
+        std::lock_guard lockGuard(m_Mutex);
+        
         std::vector<vk::PipelineStageFlags> waitStageArray(m_WaitSemaphores.size());
         std::vector<vk::CommandBuffer> commandBuffers(numCmd);
 
@@ -136,7 +144,22 @@ namespace nvrhi::vulkan
             TrackedCommandBufferPtr commandBuffer = commandList->getCurrentCmdBuf();
 
             commandBuffers[i] = commandBuffer->cmdBuf;
-            m_CommandBuffersInFlight.push_back(commandBuffer);
+
+            // If the command list provides a custom lifetime tracker, use that.
+            // Otherwise, use our own tracker.
+            CommandListLifetimeTracker* lifetimeTracker = checked_cast<CommandListLifetimeTracker*>(
+                commandList->getDesc().lifetimeTracker);
+
+            if (lifetimeTracker)
+            {
+                assert(lifetimeTracker->getQueue() == this);
+            }
+            else
+            {
+                lifetimeTracker = &m_LifetimeTracker;
+            }
+
+            lifetimeTracker->push(commandBuffer);
 
             for (const auto& buffer : commandBuffer->referencedStagingBuffers)
             {
@@ -291,20 +314,41 @@ namespace nvrhi::vulkan
         return m_LastFinishedID;
     }
 
-    void Queue::retireCommandBuffers()
+    void Queue::runGarbageCollection()
     {
-        std::list<TrackedCommandBufferPtr> submissions = std::move(m_CommandBuffersInFlight);
+        m_LifetimeTracker.runGarbageCollection();
+    }
 
-        uint64_t lastFinishedID = updateLastFinishedID();
-        
-        for (const TrackedCommandBufferPtr& cmd : submissions)
+    void Queue::returnCommandBuffersToPool(std::list<TrackedCommandBufferPtr> const& commandBuffers)
+    {
+        std::lock_guard lockGuard(m_Mutex);
+
+        m_CommandBuffersPool.insert(m_CommandBuffersPool.end(), commandBuffers.begin(), commandBuffers.end());
+    }
+
+    CommandListLifetimeTracker::CommandListLifetimeTracker(const VulkanContext& context, Queue* queue)
+	    : m_Context(context)
+		, m_Queue(queue)
+    {
+        assert(m_Queue);
+    }
+
+    void CommandListLifetimeTracker::runGarbageCollection()
+    {
+        std::list<TrackedCommandBufferPtr> releasedCmdBufs;
+
+        uint64_t lastFinishedID = m_Queue->updateLastFinishedID();
+
+        auto it = m_CommandBuffersInFlight.begin();
+        for (; it != m_CommandBuffersInFlight.end(); ++it)
         {
+            TrackedCommandBufferPtr const& cmd = *it;
             if (cmd->submissionID <= lastFinishedID)
             {
                 cmd->referencedResources.clear();
                 cmd->referencedStagingBuffers.clear();
                 cmd->submissionID = 0;
-                m_CommandBuffersPool.push_back(cmd);
+                releasedCmdBufs.push_back(cmd);
 
 #ifdef NVRHI_WITH_RTXMU
                 if (!cmd->rtxmuBuildIds.empty())
@@ -325,20 +369,20 @@ namespace nvrhi::vulkan
             }
             else
             {
-                m_CommandBuffersInFlight.push_back(cmd);
+                break;
             }
+        }
+
+        if (it != m_CommandBuffersInFlight.begin())
+        {
+            m_CommandBuffersInFlight.erase(m_CommandBuffersInFlight.begin(), it);
+            m_Queue->returnCommandBuffersToPool(releasedCmdBufs);
         }
     }
 
-    TrackedCommandBufferPtr Queue::getCommandBufferInFlight(uint64_t submissionID)
+    void CommandListLifetimeTracker::push(TrackedCommandBufferPtr commandBuffer)
     {
-        for (const TrackedCommandBufferPtr& cmd : m_CommandBuffersInFlight)
-        {
-            if (cmd->submissionID == submissionID)
-                return cmd;
-        }
-
-        return nullptr;
+        m_CommandBuffersInFlight.push_back(commandBuffer);
     }
 
     VkSemaphore Device::getQueueSemaphore(CommandQueue queueID)


### PR DESCRIPTION
This is a follow-up to PR #119 that just adds a Vulkan implementation of ICommandListLifetimeTracker.