### PR TITLE
Allow SamplerFeedbackTexture_UAV in MutableSrvUavCbv bindless layouts

### DIFF
--- a/include/nvrhi/nvrhi.h
+++ b/include/nvrhi/nvrhi.h
@@ -2040,7 +2040,8 @@ namespace nvrhi
 
             MutableSrvUavCbv,   // Corresponds to SPIR-V binding -fvk-bind-resource-heap (Counter resources ResourceDescriptorHeap)
                                 // Valid descriptor types: Texture_SRV, Texture_UAV, TypedBuffer_SRV, TypedBuffer_UAV,
-                                // StructuredBuffer_SRV, StructuredBuffer_UAV, RawBuffer_SRV, RawBuffer_UAV, ConstantBuffer
+                                // StructuredBuffer_SRV, StructuredBuffer_UAV, RawBuffer_SRV, RawBuffer_UAV, ConstantBuffer,
+                                // SamplerFeedbackTexture_UAV
 
             MutableCounters,    // Corresponds to SPIR-V binding -fvk-bind-counter-heap (Counter resources accessed via ResourceDescriptorHeap)
                                 // Valid descriptor types: StructuredBuffer_UAV

--- a/src/validation/validation-device.cpp
+++ b/src/validation/validation-device.cpp
@@ -1545,13 +1545,11 @@ namespace nvrhi::validation
                 case ResourceType::RawBuffer_SRV:
                 case ResourceType::RawBuffer_UAV:
                 case ResourceType::ConstantBuffer:
+                case ResourceType::SamplerFeedbackTexture_UAV:
                     // Valid descriptors
                     break;
                 case ResourceType::Sampler:
                     errorStream << "ResourceType::Sampler is not allowed for BindlessLayoutDesc::LayoutType::MutableSrvUavCbv." << std::endl;
-                    return false;
-                case ResourceType::SamplerFeedbackTexture_UAV:
-                    errorStream << "ResourceType::SamplerFeedbackTexture_UAV is not allowed for bindless layouts with LayoutType::MutableSrvUavCbv." << std::endl;
                     return false;
                 case ResourceType::VolatileConstantBuffer:
                     errorStream << "ResourceType::VolatileConstantBuffer is not allowed for bindless layouts with LayoutType::MutableSrvUavCbv." << std::endl;


### PR DESCRIPTION
Sampler feedback textures are UAV resources on D3D12 (created with D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, cleared via ClearUnorderedAccessViewUint). The D3D12 backend already correctly handles them:
- BindlessLayout maps SamplerFeedbackTexture_UAV -> D3D12_DESCRIPTOR_RANGE_TYPE_UAV
- writeDescriptorTable creates the correct UAV via CreateSamplerFeedbackUnorderedAccessView

The validation layer was incorrectly rejecting them. This fix:
1. Allows SamplerFeedbackTexture_UAV in the MutableSrvUavCbv validation switch
2. Updates the nvrhi.h documentation to list it as a valid descriptor type